### PR TITLE
Add ESLint 10 and Prettier, wire into CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,8 +7,8 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '22'
-        cache: 'npm'
+        node-version: "22"
+        cache: "npm"
 
     - name: Install dependencies
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,22 @@
 version: 2
 updates:
   # JavaScript/TypeScript dependencies (npm)
-  - package-ecosystem: 'npm'
-    directory: '/'
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: 'weekly'
+      interval: "weekly"
     labels:
-      - 'dependencies'
+      - "dependencies"
     commit-message:
-      prefix: 'chore(deps):'
+      prefix: "chore(deps):"
 
   # GitHub Actions
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: 'weekly'
+      interval: "weekly"
     labels:
-      - 'dependencies'
-      - 'ci'
+      - "dependencies"
+      - "ci"
     commit-message:
-      prefix: 'chore(ci):'
+      prefix: "chore(ci):"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,38 +4,38 @@
 documentation:
   - changed-files:
       - any-glob-to-any-file:
-          - '**/*.md'
+          - "**/*.md"
 
 typescript:
   - changed-files:
       - any-glob-to-any-file:
-          - 'src/**/*.ts'
-          - 'tsconfig.json'
+          - "src/**/*.ts"
+          - "tsconfig.json"
 
 schema:
   - changed-files:
       - any-glob-to-any-file:
-          - 'schemas/**/*.sql'
+          - "schemas/**/*.sql"
 
 config:
   - changed-files:
       - any-glob-to-any-file:
-          - 'wrangler.jsonc'
-          - 'package.json'
-          - 'tsconfig.json'
+          - "wrangler.jsonc"
+          - "package.json"
+          - "tsconfig.json"
 
 dependencies:
   - changed-files:
       - any-glob-to-any-file:
-          - 'package.json'
-          - 'package-lock.json'
+          - "package.json"
+          - "package-lock.json"
 
 ci:
   - changed-files:
       - any-glob-to-any-file:
-          - '.github/**/*'
+          - ".github/**/*"
 
 cloudflare:
   - changed-files:
       - any-glob-to-any-file:
-          - 'wrangler.jsonc'
+          - "wrangler.jsonc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,15 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    name: Lint
+    uses: ./.github/workflows/lint.yml
+
   typecheck:
     name: TypeCheck
     uses: ./.github/workflows/typecheck.yml
 
   build:
     name: Build
-    needs: [typecheck]
+    needs: [lint, typecheck]
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       dryRun:
-        description: 'Log actions without making changes'
+        description: "Log actions without making changes"
         type: boolean
         default: false
   schedule:
-    - cron: '0 6 * * *'
+    - cron: "0 6 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,43 @@
+name: Lint
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    name: ESLint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Prettier
+        run: |
+          set -o pipefail
+          echo "## Prettier Results" >> $GITHUB_STEP_SUMMARY
+          if npm run format:check 2>&1 | tee output.txt; then
+            echo "**All files formatted correctly**" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "**Formatting issues detected:**" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat output.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+      - name: ESLint
+        run: |
+          set -o pipefail
+          echo "## ESLint Results" >> $GITHUB_STEP_SUMMARY
+          if npm run lint 2>&1 | tee output.txt; then
+            echo "**No lint errors found**" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "**Lint errors detected:**" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat output.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,13 @@ Memory Graph MCP — a remote MCP server on Cloudflare Workers providing LLMs wi
 
 See `package.json` scripts. Summary:
 
-| Task | Command |
-|---|---|
-| Install deps | `npm install` |
-| Typecheck | `npm run typecheck` |
-| Build (dry-run) | `npm run build` |
-| Dev server (local) | `npx wrangler dev --local --port 8787` |
-| Init local D1 schema | `npm run db:init:local` |
+| Task                 | Command                                |
+| -------------------- | -------------------------------------- |
+| Install deps         | `npm install`                          |
+| Typecheck            | `npm run typecheck`                    |
+| Build (dry-run)      | `npm run build`                        |
+| Dev server (local)   | `npx wrangler dev --local --port 8787` |
+| Init local D1 schema | `npm run db:init:local`                |
 
 ### Non-obvious caveats
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ A remote MCP server on Cloudflare Workers that gives LLMs persistent, structured
 
 ## Architecture
 
-| Component | Cloudflare Service | Purpose |
-|---|---|---|
-| MCP sessions | **Durable Objects** | Stateful per-session MCP agent (`McpAgent`) |
-| Structured graph | **D1** (SQLite) | Entities, relations, memories, conversations |
-| Semantic search | **Vectorize** + **Workers AI** | Embedding-based similarity (`@cf/baai/bge-large-en-v1.5`, 1024d) |
-| Auth | **KV** + **OAuthProvider** | OAuth token/client storage, Cloudflare Access integration |
-| Cache | **KV** | Optional caching layer |
-| Blob storage | **R2** | Conversation logs, documents |
+| Component        | Cloudflare Service             | Purpose                                                          |
+| ---------------- | ------------------------------ | ---------------------------------------------------------------- |
+| MCP sessions     | **Durable Objects**            | Stateful per-session MCP agent (`McpAgent`)                      |
+| Structured graph | **D1** (SQLite)                | Entities, relations, memories, conversations                     |
+| Semantic search  | **Vectorize** + **Workers AI** | Embedding-based similarity (`@cf/baai/bge-large-en-v1.5`, 1024d) |
+| Auth             | **KV** + **OAuthProvider**     | OAuth token/client storage, Cloudflare Access integration        |
+| Cache            | **KV**                         | Optional caching layer                                           |
+| Blob storage     | **R2**                         | Conversation logs, documents                                     |
 
 ## Tools (25)
 
@@ -39,6 +39,7 @@ A remote MCP server on Cloudflare Workers that gives LLMs persistent, structured
 ## Setup
 
 ### Prerequisites
+
 - Node.js 18+
 - Cloudflare account with Workers, D1, Vectorize, and Workers AI enabled
 - [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
@@ -62,6 +63,7 @@ npx wrangler r2 bucket create memory-graph-mcp-storage
 ### 3. Update wrangler.jsonc
 
 Replace the IDs in `wrangler.jsonc` with the values printed by the commands above:
+
 - `database_id` for D1
 - `id` for each KV namespace
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,0 +1,23 @@
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+import prettier from "eslint-config-prettier";
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  prettier,
+  {
+    ignores: ["dist/", ".wrangler/", "node_modules/"],
+  },
+  {
+    files: ["src/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      "@typescript-eslint/no-explicit-any": "warn",
+      "no-console": "warn",
+    },
+  },
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,13 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250214.0",
+        "@eslint/js": "^10.0.1",
+        "eslint": "^10.0.2",
+        "eslint-config-prettier": "^10.1.8",
+        "jiti": "^2.6.1",
+        "prettier": "^3.8.1",
         "typescript": "^5.7.0",
+        "typescript-eslint": "^8.56.1",
         "wrangler": "^4.0.0"
       }
     },
@@ -1723,6 +1729,134 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.2.tgz",
+      "integrity": "sha512-YF+fE6LV4v5MGWRGj7G404/OZzGNepVF8fxk7jqmqo3lrza7a0uUcDnROGRBG1WFC1omYUS/Wp1f42i0M+3Q3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.2",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.2.tgz",
+      "integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.2.tgz",
+      "integrity": "sha512-HOy56KJt48Bx8KmJ+XGQNSUMT/6dZee/M54XyUyuvTvPXJmsERRvBchsUVx1UMe1WwIH49XLAczNC7V2INsuUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.0.tgz",
+      "integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@ethereumjs/common": {
       "version": "3.2.0",
       "license": "MIT",
@@ -1785,6 +1919,58 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@img/colour": {
@@ -5196,6 +5382,27 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/lodash": {
       "version": "4.17.24",
       "license": "MIT"
@@ -5221,6 +5428,236 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
+      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/type-utils": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.56.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
+      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
+      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@wagmi/connectors": {
@@ -5843,6 +6280,29 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "license": "MIT",
@@ -5997,6 +6457,16 @@
         "axios": "0.x || 1.x"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/base-x": {
       "version": "3.0.11",
       "license": "MIT",
@@ -6076,6 +6546,19 @@
     "node_modules/bowser": {
       "version": "2.14.1",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/bs58": {
       "version": "4.0.1",
@@ -6426,6 +6909,13 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "license": "MIT",
@@ -6717,6 +7207,276 @@
       "version": "1.0.3",
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
+      "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.2",
+        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/core": "^1.1.0",
+        "@eslint/plugin-kit": "^0.6.0",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.1",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.1.1",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.1.tgz",
+      "integrity": "sha512-GaUN0sWim5qc8KVErfPBWmc31LEsOkrUJbvJZV+xuL3u2phMUK4HIvXlWAakfC8W4nzlK+chPEAkYOYb5ZScIw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.1.tgz",
+      "integrity": "sha512-AVHPqQoZYc+RUM4/3Ly5udlZY/U4LS8pIG05jEjWM2lQMU/oaZ7qshzAl2YP1tfNmXfftH3ohurfwNAug+MnsQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "license": "MIT",
@@ -6982,6 +7742,20 @@
       "version": "3.1.3",
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-redact": {
       "version": "3.5.0",
       "license": "MIT",
@@ -7015,6 +7789,19 @@
       "version": "1.0.22",
       "license": "CC0-1.0",
       "peer": true
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/filter-obj": {
       "version": "1.1.0",
@@ -7052,6 +7839,27 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -7195,6 +8003,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "license": "MIT",
@@ -7331,6 +8152,26 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
@@ -7384,6 +8225,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "license": "MIT",
@@ -7406,6 +8257,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-promise": {
@@ -7538,6 +8402,16 @@
         }
       }
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/jose": {
       "version": "6.1.3",
       "license": "MIT",
@@ -7553,6 +8427,13 @@
       "version": "4.0.0",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-rpc-engine": {
       "version": "6.1.0",
@@ -7585,6 +8466,13 @@
       "version": "8.0.2",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "license": "ISC"
@@ -7602,6 +8490,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/keyvaluestorage-interface": {
       "version": "1.0.0",
       "license": "MIT"
@@ -7612,6 +8510,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lit": {
@@ -7779,6 +8691,22 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/mipd": {
       "version": "0.0.7",
       "funding": [
@@ -7820,6 +8748,13 @@
       "engines": {
         "node": "^18 || >=20"
       }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -7968,6 +8903,24 @@
     "node_modules/openapi-typescript-helpers": {
       "version": "0.0.15",
       "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/ox": {
       "version": "0.12.4",
@@ -8253,6 +9206,32 @@
         "url": "https://opencollective.com/preact"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "license": "MIT"
@@ -8286,6 +9265,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qrcode": {
@@ -8853,6 +9842,54 @@
         "real-require": "^0.1.0"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/to-buffer": {
       "version": "1.2.2",
       "license": "MIT",
@@ -8876,9 +9913,35 @@
       "version": "0.0.3",
       "license": "MIT"
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/type-is": {
       "version": "2.0.1",
@@ -8913,6 +9976,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.1.tgz",
+      "integrity": "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.56.1",
+        "@typescript-eslint/parser": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/ufo": {
@@ -9049,6 +10136,16 @@
         "uploadthing": {
           "optional": true
         }
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/use-sync-external-store": {
@@ -9251,6 +10348,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/workerd": {
       "version": "1.20260302.0",
       "dev": true,
@@ -9423,6 +10530,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/youch": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "build": "wrangler deploy --dry-run --outdir=dist",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint": "eslint src/",
+    "lint:fix": "eslint src/ --fix",
     "typecheck": "tsc --noEmit",
     "db:init": "wrangler d1 execute memory-graph-mcp-db --remote --file=schemas/schema.sql",
     "db:init:local": "wrangler d1 execute memory-graph-mcp-db --local --file=schemas/schema.sql"
@@ -19,7 +23,13 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250214.0",
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.0.2",
+    "eslint-config-prettier": "^10.1.8",
+    "jiti": "^2.6.1",
+    "prettier": "^3.8.1",
     "typescript": "^5.7.0",
+    "typescript-eslint": "^8.56.1",
     "wrangler": "^4.0.0"
   }
 }

--- a/src/access-handler.ts
+++ b/src/access-handler.ts
@@ -89,11 +89,15 @@ export async function handleAccessRequest(
         "Set-Cookie": approvedClientCookie,
       });
     } catch (error: unknown) {
+      // eslint-disable-next-line no-console
       console.error("POST /authorize error:", error);
       if (error instanceof OAuthError) {
         return error.toResponse();
       }
-      return new Response(`Internal server error: ${error instanceof Error ? error.message : "unknown"}`, { status: 500 });
+      return new Response(
+        `Internal server error: ${error instanceof Error ? error.message : "unknown"}`,
+        { status: 500 },
+      );
     }
   }
 

--- a/src/conversations.ts
+++ b/src/conversations.ts
@@ -1,7 +1,7 @@
 /**
  * Conversation and message history operations.
  */
-import type { Env, ConversationRow, MessageRow } from "./types.js";
+import type { ConversationRow, MessageRow } from "./types.js";
 import { generateId, now, toJson } from "./utils.js";
 
 export async function createConversation(
@@ -10,9 +10,7 @@ export async function createConversation(
 ): Promise<string> {
   const id = generateId();
   await db
-    .prepare(
-      `INSERT INTO conversations (id, namespace_id, title, metadata) VALUES (?, ?, ?, ?)`,
-    )
+    .prepare(`INSERT INTO conversations (id, namespace_id, title, metadata) VALUES (?, ?, ?, ?)`)
     .bind(id, opts.namespace_id, opts.title ?? null, toJson(opts.metadata ?? null))
     .run();
   return id;
@@ -79,7 +77,10 @@ export async function getMessages(
   params.push(limit);
 
   const sql = `SELECT * FROM messages WHERE ${clauses.join(" AND ")} ORDER BY created_at DESC LIMIT ?`;
-  const result = await db.prepare(sql).bind(...params).all<MessageRow>();
+  const result = await db
+    .prepare(sql)
+    .bind(...params)
+    .all<MessageRow>();
   // Return in chronological order
   return result.results.reverse();
 }

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -13,7 +13,7 @@ const EMBEDDING_MODEL = "@cf/baai/bge-large-en-v1.5";
  * Generate an embedding vector for the given text using Workers AI.
  */
 export async function embed(ai: Ai, text: string): Promise<number[]> {
-  const result = await ai.run(EMBEDDING_MODEL, { text: [text] }) as { data: number[][] };
+  const result = (await ai.run(EMBEDDING_MODEL, { text: [text] })) as { data: number[][] };
   return result.data[0];
 }
 

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -2,8 +2,8 @@
  * Core graph operations against D1.
  * Handles entities, relations, namespaces, and graph traversal.
  */
-import type { Env, EntityRow, RelationRow, NamespaceRow } from "./types.js";
-import { generateId, now, parseJson, toJson } from "./utils.js";
+import type { EntityRow, RelationRow, NamespaceRow } from "./types.js";
+import { generateId, now, toJson } from "./utils.js";
 
 // ---- Namespaces ----
 
@@ -16,7 +16,13 @@ export async function createNamespace(
     .prepare(
       `INSERT INTO namespaces (id, name, description, owner, metadata) VALUES (?, ?, ?, ?, ?)`,
     )
-    .bind(id, opts.name, opts.description ?? null, opts.owner ?? null, toJson(opts.metadata ?? null))
+    .bind(
+      id,
+      opts.name,
+      opts.description ?? null,
+      opts.owner ?? null,
+      toJson(opts.metadata ?? null),
+    )
     .run();
   return id;
 }
@@ -33,7 +39,9 @@ export async function listNamespaces(db: D1Database, owner?: string): Promise<Na
       .all<NamespaceRow>();
     return result.results;
   }
-  const result = await db.prepare(`SELECT * FROM namespaces ORDER BY created_at DESC`).all<NamespaceRow>();
+  const result = await db
+    .prepare(`SELECT * FROM namespaces ORDER BY created_at DESC`)
+    .all<NamespaceRow>();
   return result.results;
 }
 
@@ -55,7 +63,14 @@ export async function createEntity(
       `INSERT INTO entities (id, namespace_id, name, type, summary, metadata)
        VALUES (?, ?, ?, ?, ?, ?)`,
     )
-    .bind(id, opts.namespace_id, opts.name, opts.type, opts.summary ?? null, toJson(opts.metadata ?? null))
+    .bind(
+      id,
+      opts.namespace_id,
+      opts.name,
+      opts.type,
+      opts.summary ?? null,
+      toJson(opts.metadata ?? null),
+    )
     .run();
   return id;
 }
@@ -95,7 +110,10 @@ export async function searchEntities(
   params.push(limit);
 
   const sql = `SELECT * FROM entities WHERE ${clauses.join(" AND ")} ORDER BY last_accessed_at DESC LIMIT ?`;
-  const result = await db.prepare(sql).bind(...params).all<EntityRow>();
+  const result = await db
+    .prepare(sql)
+    .bind(...params)
+    .all<EntityRow>();
   return result.results;
 }
 
@@ -107,13 +125,28 @@ export async function updateEntity(
   const sets: string[] = ["updated_at = ?"];
   const params: unknown[] = [now()];
 
-  if (updates.name !== undefined) { sets.push("name = ?"); params.push(updates.name); }
-  if (updates.type !== undefined) { sets.push("type = ?"); params.push(updates.type); }
-  if (updates.summary !== undefined) { sets.push("summary = ?"); params.push(updates.summary); }
-  if (updates.metadata !== undefined) { sets.push("metadata = ?"); params.push(toJson(updates.metadata)); }
+  if (updates.name !== undefined) {
+    sets.push("name = ?");
+    params.push(updates.name);
+  }
+  if (updates.type !== undefined) {
+    sets.push("type = ?");
+    params.push(updates.type);
+  }
+  if (updates.summary !== undefined) {
+    sets.push("summary = ?");
+    params.push(updates.summary);
+  }
+  if (updates.metadata !== undefined) {
+    sets.push("metadata = ?");
+    params.push(toJson(updates.metadata));
+  }
 
   params.push(id);
-  await db.prepare(`UPDATE entities SET ${sets.join(", ")} WHERE id = ?`).bind(...params).run();
+  await db
+    .prepare(`UPDATE entities SET ${sets.join(", ")} WHERE id = ?`)
+    .bind(...params)
+    .run();
 }
 
 export async function deleteEntity(db: D1Database, id: string): Promise<void> {
@@ -178,7 +211,10 @@ export async function getRelationsFrom(
     WHERE ${clauses.join(" AND ")}
     ORDER BY r.weight DESC
     LIMIT ?`;
-  const result = await db.prepare(sql).bind(...params).all<RelationRow & { target_name: string; target_type: string }>();
+  const result = await db
+    .prepare(sql)
+    .bind(...params)
+    .all<RelationRow & { target_name: string; target_type: string }>();
   return result.results;
 }
 
@@ -205,7 +241,10 @@ export async function getRelationsTo(
     WHERE ${clauses.join(" AND ")}
     ORDER BY r.weight DESC
     LIMIT ?`;
-  const result = await db.prepare(sql).bind(...params).all<RelationRow & { source_name: string; source_type: string }>();
+  const result = await db
+    .prepare(sql)
+    .bind(...params)
+    .all<RelationRow & { source_name: string; source_type: string }>();
   return result.results;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,6 @@ import {
   assertMemoryAccess,
   assertConversationAccess,
   assertRelationAccess,
-  AccessDeniedError,
 } from "./auth.js";
 
 export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthProps> {
@@ -57,7 +56,11 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
         description: z.string().optional().describe("What this namespace is for"),
       },
       async ({ name, description }) => {
-        const id = await graph.createNamespace(this.env.DB, { name, description, owner: this.email });
+        const id = await graph.createNamespace(this.env.DB, {
+          name,
+          description,
+          owner: this.email,
+        });
         return { content: [{ type: "text" as const, text: JSON.stringify({ id, name }) }] };
       },
     );
@@ -82,7 +85,9 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
       {
         namespace_id: z.string().describe("Namespace to create the entity in"),
         name: z.string().describe("Entity name"),
-        type: z.string().describe("Entity type: person, concept, project, tool, location, organization, etc."),
+        type: z
+          .string()
+          .describe("Entity type: person, concept, project, tool, location, organization, etc."),
         summary: z.string().optional().describe("Brief description of the entity"),
         metadata: z.string().optional().describe("Optional JSON string of additional properties"),
       },
@@ -117,7 +122,12 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
         const entity = await graph.getEntity(this.env.DB, id);
         if (!entity) return { content: [{ type: "text" as const, text: "Entity not found" }] };
         return {
-          content: [{ type: "text" as const, text: JSON.stringify({ ...entity, metadata: parseJson(entity.metadata) }) }],
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ ...entity, metadata: parseJson(entity.metadata) }),
+            },
+          ],
         };
       },
     );
@@ -133,7 +143,11 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
       },
       async ({ namespace_id, query, type, limit }) => {
         await assertNamespaceAccess(this.env.DB, namespace_id, this.email);
-        const results = await graph.searchEntities(this.env.DB, namespace_id, { query, type, limit });
+        const results = await graph.searchEntities(this.env.DB, namespace_id, {
+          query,
+          type,
+          limit,
+        });
         return { content: [{ type: "text" as const, text: JSON.stringify(results) }] };
       },
     );
@@ -197,7 +211,9 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
         namespace_id: z.string(),
         source_id: z.string().describe("Source entity ID (from)"),
         target_id: z.string().describe("Target entity ID (to)"),
-        relation_type: z.string().describe("Relationship label: knows, uses, depends_on, part_of, related_to, etc."),
+        relation_type: z
+          .string()
+          .describe("Relationship label: knows, uses, depends_on, part_of, related_to, etc."),
         weight: z.number().optional().describe("Strength of relation 0.0-1.0 (default 1.0)"),
         metadata: z.string().optional().describe("Optional JSON string of additional properties"),
       },
@@ -212,7 +228,12 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
           metadata: metadata ? JSON.parse(metadata) : undefined,
         });
         return {
-          content: [{ type: "text" as const, text: JSON.stringify({ id, source_id, target_id, relation_type }) }],
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ id, source_id, target_id, relation_type }),
+            },
+          ],
         };
       },
     );
@@ -222,7 +243,10 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
       "Get all relations from or to an entity",
       {
         entity_id: z.string().describe("Entity ID"),
-        direction: z.enum(["from", "to", "both"]).optional().describe("Direction of relations (default: both)"),
+        direction: z
+          .enum(["from", "to", "both"])
+          .optional()
+          .describe("Direction of relations (default: both)"),
         relation_type: z.string().optional().describe("Filter by relation type"),
         limit: z.number().optional(),
       },
@@ -232,7 +256,10 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
         const results: unknown[] = [];
 
         if (dir === "from" || dir === "both") {
-          const rels = await graph.getRelationsFrom(this.env.DB, entity_id, { relation_type, limit });
+          const rels = await graph.getRelationsFrom(this.env.DB, entity_id, {
+            relation_type,
+            limit,
+          });
           results.push(...rels.map((r) => ({ ...r, direction: "outgoing" })));
         }
         if (dir === "to" || dir === "both") {
@@ -316,7 +343,9 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
           content,
           type: type ?? "fact",
         });
-        return { content: [{ type: "text" as const, text: JSON.stringify({ id, type: type ?? "fact" }) }] };
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ id, type: type ?? "fact" }) }],
+        };
       },
     );
 
@@ -346,7 +375,11 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
       },
       async ({ namespace_id, query, type, limit }) => {
         await assertNamespaceAccess(this.env.DB, namespace_id, this.email);
-        const results = await memories.searchMemories(this.env.DB, namespace_id, { query, type, limit });
+        const results = await memories.searchMemories(this.env.DB, namespace_id, {
+          query,
+          type,
+          limit,
+        });
         return { content: [{ type: "text" as const, text: JSON.stringify(results) }] };
       },
     );
@@ -504,7 +537,9 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
       },
       async ({ namespace_id, query, limit }) => {
         await assertNamespaceAccess(this.env.DB, namespace_id, this.email);
-        const results = await conversations.searchMessages(this.env.DB, namespace_id, query, { limit });
+        const results = await conversations.searchMessages(this.env.DB, namespace_id, query, {
+          limit,
+        });
         return { content: [{ type: "text" as const, text: JSON.stringify(results) }] };
       },
     );
@@ -527,7 +562,10 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
       },
       async ({ namespace_id, query, kind, limit }) => {
         await assertNamespaceAccess(this.env.DB, namespace_id, this.email);
-        const results = await embeddings.semanticSearch(this.env, query, namespace_id, { kind, limit });
+        const results = await embeddings.semanticSearch(this.env, query, namespace_id, {
+          kind,
+          limit,
+        });
         return { content: [{ type: "text" as const, text: JSON.stringify(results) }] };
       },
     );
@@ -548,7 +586,9 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
         await assertNamespaceAccess(this.env.DB, namespace_id, this.email);
         const n = limit ?? 5;
 
-        const semanticResults = await embeddings.semanticSearch(this.env, query, namespace_id, { limit: n });
+        const semanticResults = await embeddings.semanticSearch(this.env, query, namespace_id, {
+          limit: n,
+        });
 
         const entityContext: unknown[] = [];
         for (const result of semanticResults.filter((r) => r.kind === "entity")) {
@@ -570,7 +610,9 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
           });
         }
 
-        const rankedMemories = await memories.recallMemories(this.env.DB, namespace_id, { limit: n });
+        const rankedMemories = await memories.recallMemories(this.env.DB, namespace_id, {
+          limit: n,
+        });
         const keywordMemories = await memories.searchMemories(this.env.DB, namespace_id, {
           query,
           limit: n,
@@ -583,7 +625,7 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
           keyword_memories: keywordMemories,
         };
 
-         return { content: [{ type: "text" as const, text: JSON.stringify(context) }] };
+        return { content: [{ type: "text" as const, text: JSON.stringify(context) }] };
       },
     );
 
@@ -608,12 +650,19 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
         let errorCount = 0;
 
         // Get entities to reindex (scoped to user's namespaces)
-        const entityQuery = namespace_id === "all"
-          ? "SELECT e.id, e.namespace_id, e.name, e.type, e.summary FROM entities e JOIN namespaces n ON n.id = e.namespace_id WHERE n.owner = ? OR n.owner IS NULL"
-          : "SELECT id, namespace_id, name, type, summary FROM entities WHERE namespace_id = ?";
+        const entityQuery =
+          namespace_id === "all"
+            ? "SELECT e.id, e.namespace_id, e.name, e.type, e.summary FROM entities e JOIN namespaces n ON n.id = e.namespace_id WHERE n.owner = ? OR n.owner IS NULL"
+            : "SELECT id, namespace_id, name, type, summary FROM entities WHERE namespace_id = ?";
         const entityResult = await this.env.DB.prepare(entityQuery)
           .bind(namespace_id === "all" ? this.email : namespace_id)
-          .all<{ id: string; namespace_id: string; name: string; type: string; summary: string | null }>();
+          .all<{
+            id: string;
+            namespace_id: string;
+            name: string;
+            type: string;
+            summary: string | null;
+          }>();
 
         for (const entity of entityResult.results) {
           try {
@@ -631,9 +680,10 @@ export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthPro
         }
 
         // Get memories to reindex (scoped to user's namespaces)
-        const memoryQuery = namespace_id === "all"
-          ? "SELECT m.id, m.namespace_id, m.content, m.type FROM memories m JOIN namespaces n ON n.id = m.namespace_id WHERE n.owner = ? OR n.owner IS NULL"
-          : "SELECT id, namespace_id, content, type FROM memories WHERE namespace_id = ?";
+        const memoryQuery =
+          namespace_id === "all"
+            ? "SELECT m.id, m.namespace_id, m.content, m.type FROM memories m JOIN namespaces n ON n.id = m.namespace_id WHERE n.owner = ? OR n.owner IS NULL"
+            : "SELECT id, namespace_id, content, type FROM memories WHERE namespace_id = ?";
         const memoryResult = await this.env.DB.prepare(memoryQuery)
           .bind(namespace_id === "all" ? this.email : namespace_id)
           .all<{ id: string; namespace_id: string; content: string; type: string }>();

--- a/src/memories.ts
+++ b/src/memories.ts
@@ -1,7 +1,7 @@
 /**
  * Memory operations: standalone knowledge fragments with temporal decay.
  */
-import type { Env, MemoryRow } from "./types.js";
+import type { MemoryRow } from "./types.js";
 import { generateId, now, toJson, decayScore } from "./utils.js";
 
 export async function createMemory(
@@ -78,7 +78,10 @@ export async function searchMemories(
   params.push(limit);
 
   const sql = `SELECT * FROM memories WHERE ${clauses.join(" AND ")} ORDER BY importance DESC, last_accessed_at DESC LIMIT ?`;
-  const result = await db.prepare(sql).bind(...params).all<MemoryRow>();
+  const result = await db
+    .prepare(sql)
+    .bind(...params)
+    .all<MemoryRow>();
   return result.results;
 }
 
@@ -103,7 +106,10 @@ export async function recallMemories(
   params.push(pool);
 
   const sql = `SELECT * FROM memories WHERE ${clauses.join(" AND ")} ORDER BY last_accessed_at DESC LIMIT ?`;
-  const result = await db.prepare(sql).bind(...params).all<MemoryRow>();
+  const result = await db
+    .prepare(sql)
+    .bind(...params)
+    .all<MemoryRow>();
 
   const scored = result.results.map((m) => ({
     ...m,
@@ -136,18 +142,38 @@ export async function getMemoriesForEntity(
 export async function updateMemory(
   db: D1Database,
   id: string,
-  updates: { content?: string; type?: string; importance?: number; metadata?: Record<string, unknown> },
+  updates: {
+    content?: string;
+    type?: string;
+    importance?: number;
+    metadata?: Record<string, unknown>;
+  },
 ): Promise<void> {
   const sets: string[] = ["updated_at = ?"];
   const params: unknown[] = [now()];
 
-  if (updates.content !== undefined) { sets.push("content = ?"); params.push(updates.content); }
-  if (updates.type !== undefined) { sets.push("type = ?"); params.push(updates.type); }
-  if (updates.importance !== undefined) { sets.push("importance = ?"); params.push(updates.importance); }
-  if (updates.metadata !== undefined) { sets.push("metadata = ?"); params.push(toJson(updates.metadata)); }
+  if (updates.content !== undefined) {
+    sets.push("content = ?");
+    params.push(updates.content);
+  }
+  if (updates.type !== undefined) {
+    sets.push("type = ?");
+    params.push(updates.type);
+  }
+  if (updates.importance !== undefined) {
+    sets.push("importance = ?");
+    params.push(updates.importance);
+  }
+  if (updates.metadata !== undefined) {
+    sets.push("metadata = ?");
+    params.push(toJson(updates.metadata));
+  }
 
   params.push(id);
-  await db.prepare(`UPDATE memories SET ${sets.join(", ")} WHERE id = ?`).bind(...params).run();
+  await db
+    .prepare(`UPDATE memories SET ${sets.join(", ")} WHERE id = ?`)
+    .bind(...params)
+    .run();
 }
 
 export async function deleteMemory(db: D1Database, id: string): Promise<void> {

--- a/src/workers-oauth-utils.ts
+++ b/src/workers-oauth-utils.ts
@@ -173,8 +173,7 @@ export async function addApprovedClient(
   const approvedClientsCookieName = "__Host-APPROVED_CLIENTS";
   const THIRTY_DAYS_IN_SECONDS = 2592000;
 
-  const existingApprovedClients =
-    (await getApprovedClientsFromCookie(request, cookieSecret)) || [];
+  const existingApprovedClients = (await getApprovedClientsFromCookie(request, cookieSecret)) || [];
   const updatedApprovedClients = Array.from(new Set([...existingApprovedClients, clientId]));
 
   const payload = JSON.stringify(updatedApprovedClients);
@@ -366,7 +365,10 @@ async function getApprovedClientsFromCookie(
 
   try {
     const approvedClients = JSON.parse(payload);
-    if (!Array.isArray(approvedClients) || !approvedClients.every((item) => typeof item === "string")) {
+    if (
+      !Array.isArray(approvedClients) ||
+      !approvedClients.every((item) => typeof item === "string")
+    ) {
       return null;
     }
     return approvedClients as string[];
@@ -384,7 +386,11 @@ async function signData(data: string, secret: string): Promise<string> {
     .join("");
 }
 
-async function verifySignature(signatureHex: string, data: string, secret: string): Promise<boolean> {
+async function verifySignature(
+  signatureHex: string,
+  data: string,
+  secret: string,
+): Promise<boolean> {
   const key = await importKey(secret);
   const enc = new TextEncoder();
   try {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,15 +9,15 @@
     "bindings": [
       {
         "name": "MCP_OBJECT",
-        "class_name": "MemoryGraphMCP"
-      }
-    ]
+        "class_name": "MemoryGraphMCP",
+      },
+    ],
   },
   "migrations": [
     {
       "tag": "v1",
-      "new_sqlite_classes": ["MemoryGraphMCP"]
-    }
+      "new_sqlite_classes": ["MemoryGraphMCP"],
+    },
   ],
 
   // D1 database for the structured graph, memories, and conversations
@@ -25,41 +25,41 @@
     {
       "binding": "DB",
       "database_name": "memory-graph-mcp-db",
-      "database_id": "080fbc1c-3431-4ea6-9a8e-427244e21e05"
-    }
+      "database_id": "080fbc1c-3431-4ea6-9a8e-427244e21e05",
+    },
   ],
 
   // Vectorize index for semantic search
   "vectorize": [
     {
       "binding": "VECTORIZE",
-      "index_name": "memory-graph-mcp-embeddings"
-    }
+      "index_name": "memory-graph-mcp-embeddings",
+    },
   ],
 
   // Workers AI for generating embeddings
   "ai": {
-    "binding": "AI"
+    "binding": "AI",
   },
 
   // KV for optional caching (hot graph fragments, etc.)
   "kv_namespaces": [
     {
       "binding": "CACHE",
-      "id": "94ae719d3fd842ec93f0728ad6771030"
+      "id": "94ae719d3fd842ec93f0728ad6771030",
     },
     {
       "binding": "OAUTH_KV",
-      "id": "acbe5f3da3534db19bbe2c9b727298a8"
-    }
+      "id": "acbe5f3da3534db19bbe2c9b727298a8",
+    },
   ],
 
   // R2 bucket for blob storage (conversation logs, documents, etc.)
   "r2_buckets": [
     {
       "binding": "STORAGE",
-      "bucket_name": "memory-graph-mcp-storage"
-    }
+      "bucket_name": "memory-graph-mcp-storage",
+    },
   ],
 
   // Observability — logs enabled for debugging OAuth + MCP flows
@@ -70,12 +70,12 @@
       "enabled": true,
       "head_sampling_rate": 1,
       "persist": true,
-      "invocation_logs": true
+      "invocation_logs": true,
     },
     "traces": {
       "enabled": false,
       "persist": true,
-      "head_sampling_rate": 1
-    }
-  }
+      "head_sampling_rate": 1,
+    },
+  },
 }


### PR DESCRIPTION
## Summary
- Add ESLint 10.x with typescript-eslint and Prettier 3.x
- Fix 5 lint errors (unused imports) and format all files
- Add `lint`, `lint:fix`, `format`, `format:check` scripts
- Add lint workflow (Prettier + ESLint) to CI pipeline, gating build