### PR TITLE
chore: single source of truth versioning with git-cliff release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type (leave empty for auto-detect from commits)"
+        required: false
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine next version
+        id: version
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          echo "current=v${CURRENT}" >> "$GITHUB_OUTPUT"
+
+          BUMP_ARG=""
+          if [ "${{ inputs.bump }}" != "auto" ] && [ -n "${{ inputs.bump }}" ]; then
+            BUMP_ARG="--bump ${{ inputs.bump }}"
+          else
+            BUMP_ARG="--bump"
+          fi
+
+          NEXT=$(npx git-cliff --bumped-version $BUMP_ARG 2>/dev/null || echo "")
+          if [ -z "$NEXT" ]; then
+            echo "No version bump detected from commits"
+            exit 1
+          fi
+
+          echo "next=${NEXT}" >> "$GITHUB_OUTPUT"
+          echo "next_bare=${NEXT#v}" >> "$GITHUB_OUTPUT"
+          echo "Bumping from v${CURRENT} to ${NEXT}"
+
+      - name: Bump package.json version
+        run: npm version "${{ steps.version.outputs.next_bare }}" --no-git-tag-version
+
+      - name: Generate changelog
+        run: npx git-cliff --tag "${{ steps.version.outputs.next }}" -o CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit, tag, and push
+        run: |
+          git add package.json package-lock.json CHANGELOG.md
+          git commit -m "chore(release): ${{ steps.version.outputs.next }}"
+          git tag "${{ steps.version.outputs.next }}" -m "Release ${{ steps.version.outputs.next }}"
+          git push origin main --follow-tags
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          npx git-cliff --latest --strip header > RELEASE_NOTES.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub release
+        run: |
+          gh release create "${{ steps.version.outputs.next }}" \
+            --title "${{ steps.version.outputs.next }}" \
+            --notes-file RELEASE_NOTES.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,8 @@ See `package.json` scripts. Summary:
 - **AI and Vectorize not available locally:** When running `--local`, the Workers AI and Vectorize bindings show "not supported". Tools that rely on embeddings/semantic search will fail gracefully. D1, KV, R2, and Durable Objects all work locally.
 - **Local D1 must be initialized:** Before first dev server run, execute `npm run db:init:local` to create the SQLite tables in `.wrangler/state/`.
 - **OAuth flow requires Cloudflare Access secrets:** The full OAuth login flow needs `ACCESS_CLIENT_ID`, `ACCESS_CLIENT_SECRET`, `ACCESS_TOKEN_URL`, `ACCESS_AUTHORIZATION_URL`, `ACCESS_JWKS_URL`, and `COOKIE_ENCRYPTION_KEY` in `.dev.vars`. Without these, the `/health`, `/register`, and `/.well-known/oauth-authorization-server` endpoints still work, but the `/authorize` → `/callback` flow and authenticated MCP tool calls will not.
-- **Health endpoint:** `GET /health` returns `{"status":"ok","server":"memory-graph-mcp","version":"0.1.0"}` and requires no authentication — use it to verify the server is running.
+- **Health endpoint:** `GET /health` returns `{"status":"ok","server":"memory-graph-mcp","version":"<version>"}` and requires no authentication — use it to verify the server is running.
+- **Version is in `package.json` only.** The `src/version.ts` module reads it at build time. Never hardcode version strings elsewhere. To release, use the Release workflow dispatch in GitHub Actions.
 
 ### File structure
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -54,6 +54,13 @@ filter_commits = false
 sort_commits = "oldest"
 topo_order_commits = true
 
+[bump]
+# Detect semver bump from conventional commits:
+#   feat  -> minor
+#   fix   -> patch
+#   feat! -> major
+initial_tag = "v0.1.0"
+
 [remote.github]
 owner = "FlarelyLegal"
 repo = "memory-mcp"

--- a/src/access-handler.ts
+++ b/src/access-handler.ts
@@ -19,6 +19,7 @@ import {
   validateOAuthState,
 } from "./oauth/index.js";
 import { verifyToken } from "./jwt.js";
+import { VERSION, SERVER_NAME } from "./version.js";
 
 export async function handleAccessRequest(
   request: Request,
@@ -152,10 +153,9 @@ export async function handleAccessRequest(
   }
 
   if (pathname === "/health") {
-    return new Response(
-      JSON.stringify({ status: "ok", server: "memory-graph-mcp", version: "0.1.0" }),
-      { headers: { "content-type": "application/json" } },
-    );
+    return new Response(JSON.stringify({ status: "ok", server: SERVER_NAME, version: VERSION }), {
+      headers: { "content-type": "application/json" },
+    });
   }
 
   return new Response("Not Found", { status: 404 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import type { Env, AuthProps } from "./types.js";
+import { VERSION } from "./version.js";
 import { handleAccessRequest } from "./access-handler.js";
 
 // Tool registration modules
@@ -30,7 +31,7 @@ import { registerAdminTools } from "./tools/admin.js";
 export class MemoryGraphMCP extends McpAgent<Env, Record<string, never>, AuthProps> {
   server = new McpServer({
     name: "Memory Graph",
-    version: "0.1.0",
+    version: VERSION,
   });
 
   /** Get the authenticated user's email, or throw. */

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,5 @@
+/** Single source of truth — reads version from package.json at build time. */
+import pkg from "../package.json";
+
+export const VERSION: string = pkg.version;
+export const SERVER_NAME = "memory-graph-mcp";


### PR DESCRIPTION
## Summary

Establishes `package.json` as the single source of truth for the project version, eliminates all hardcoded version strings, and adds an automated release workflow.

## Changes

### Version centralization
- **`src/version.ts`** — new module that reads `version` from `package.json` at build time and exports `VERSION` and `SERVER_NAME`
- **`src/index.ts`** — McpServer now uses `VERSION` instead of hardcoded `"0.1.0"`
- **`src/access-handler.ts`** — `/health` endpoint now uses `VERSION` and `SERVER_NAME`
- No more hardcoded version strings anywhere in `src/`

### Release workflow (`.github/workflows/release.yml`)
Manual dispatch with optional bump type override:
1. git-cliff auto-detects bump from conventional commits (or use explicit patch/minor/major)
2. Bumps `package.json` via `npm version`
3. Generates `CHANGELOG.md` with git-cliff
4. Commits, tags (`vX.Y.Z`), pushes to main
5. Creates a GitHub release with generated notes

### Config
- `cliff.toml` — added `[bump]` section with `initial_tag = "v0.1.0"`
- `AGENTS.md` — documents versioning approach

## How it works

```
package.json (version) ──build──> src/version.ts ──import──> index.ts, access-handler.ts
                         │
                         └── Release workflow: npm version → git tag → git-cliff → GH release
```