### PR TITLE
chore: add job summaries, auto-changelog, bump all actions to latest

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: "24"
         cache: "npm"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,66 @@
+name: Changelog
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "CHANGELOG.md"
+
+permissions:
+  contents: write
+
+jobs:
+  changelog:
+    name: Update Changelog
+    runs-on: ubuntu-latest
+    # Skip commits made by this workflow to avoid infinite loops
+    if: github.event.head_commit.author.name != 'github-actions[bot]'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Generate changelog
+        run: npx git-cliff -o CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync README badges
+        run: |
+          NODE_MIN=$(node -p "require('./package.json').engines?.node?.replace('>=','') || '24'")
+          TS_VER=$(node -p "require('./package.json').devDependencies.typescript.replace('^','').split('.').slice(0,2).join('.')")
+          MCP_VER=$(node -p "require('./package.json').dependencies['@modelcontextprotocol/sdk'].replace('^','').split('.').slice(0,2).join('.')")
+
+          sed -i "s|Node.js-[^-]*-5FA04E|Node.js-≥${NODE_MIN}-5FA04E|" README.md
+          sed -i "s|TypeScript-[^-]*-3178C6|TypeScript-${TS_VER}-3178C6|" README.md
+          sed -i "s|MCP_SDK-[^-]*-blue|MCP_SDK-${MCP_VER}-blue|" README.md
+
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet CHANGELOG.md README.md; then
+            echo "No changes detected"
+            echo "## Changelog" >> "$GITHUB_STEP_SUMMARY"
+            echo "No changes detected." >> "$GITHUB_STEP_SUMMARY"
+          else
+            git add CHANGELOG.md README.md
+            git commit -m "docs: update changelog and badges [skip ci]"
+            git push
+            echo "## Changelog" >> "$GITHUB_STEP_SUMMARY"
+            echo "CHANGELOG.md and README badges updated." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -54,16 +54,19 @@ jobs:
           if [ "$HEAD_OWNER" != "$REPO_OWNER" ]; then
             echo "Skipping: PR is from a fork ($HEAD_OWNER != $REPO_OWNER)"
             echo "skip=true" >> $GITHUB_OUTPUT
+            echo "reason=PR is from a fork ($HEAD_OWNER)" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           if [ "$BASE_REF" != "main" ]; then
             echo "Skipping: PR targets '$BASE_REF', not 'main'"
             echo "skip=true" >> $GITHUB_OUTPUT
+            echo "reason=PR targets '$BASE_REF', not 'main'" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           echo "skip=false" >> $GITHUB_OUTPUT
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
       - name: Checkout PR branch
         if: (github.event.issue.pull_request || github.event.pull_request) && steps.check-pr.outputs.skip != 'true'
@@ -86,3 +89,21 @@ jobs:
           CLOUDFLARE_GATEWAY_ID: ${{ secrets.CLOUDFLARE_GATEWAY_ID }}
         with:
           model: cloudflare-ai-gateway/anthropic/claude-sonnet-4-5
+
+      - name: Job summary
+        if: always()
+        run: |
+          echo "## OpenCode Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| | |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Triggered by** | @${{ github.event.comment.user.login }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Comment** | \`${{ github.event.comment.body }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.check-pr.outputs.skip }}" = "true" ]; then
+            echo "| **Status** | Skipped |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| **Reason** | ${{ steps.check-pr.outputs.reason }} |" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "| **Status** | Ran |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| **PR** | #${{ steps.check-pr.outputs.pr_number || github.event.issue.number }} |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| **Model** | \`claude-sonnet-4-5\` |" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
           cache: "npm"
@@ -57,6 +57,8 @@ jobs:
           NEXT=$(npx git-cliff --bumped-version $BUMP_ARG 2>/dev/null || echo "")
           if [ -z "$NEXT" ]; then
             echo "No version bump detected from commits"
+            echo "## Release Failed" >> "$GITHUB_STEP_SUMMARY"
+            echo "No version bump detected from conventional commits." >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
 
@@ -80,9 +82,7 @@ jobs:
           git push origin main --follow-tags
 
       - name: Generate release notes
-        id: notes
-        run: |
-          npx git-cliff --latest --strip header > RELEASE_NOTES.md
+        run: npx git-cliff --latest --strip header > RELEASE_NOTES.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -93,3 +93,15 @@ jobs:
             --notes-file RELEASE_NOTES.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Job summary
+        if: always()
+        run: |
+          echo "## Release Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| | |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Previous** | \`${{ steps.version.outputs.current }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **New** | \`${{ steps.version.outputs.next }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Bump** | \`${{ inputs.bump || 'auto' }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Release** | [View](https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.next }}) |" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # Memory Graph MCP
 
-[![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)](https://developers.cloudflare.com/workers/)
-[![MCP SDK](https://img.shields.io/badge/MCP_SDK-1.18-blue?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBmaWxsPSJ3aGl0ZSIgZD0iTTEyIDJMMiA3djEwbDEwIDUgMTAtNVY3eiIvPjwvc3ZnPg==)](https://modelcontextprotocol.io)
+<!-- badges:start -->
+
+[![CI](https://github.com/FlarelyLegal/memory-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/FlarelyLegal/memory-mcp/actions/workflows/ci.yml)
+[![Node.js](https://img.shields.io/badge/Node.js-≥24-5FA04E?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
-[![Wrangler](https://img.shields.io/badge/Wrangler-4.x-F38020?logo=cloudflare&logoColor=white)](https://developers.cloudflare.com/workers/wrangler/)
+[![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)](https://developers.cloudflare.com/workers/)
+[![MCP SDK](https://img.shields.io/badge/MCP_SDK-1.27-blue)](https://modelcontextprotocol.io)
+
+<!-- badges:end -->
 
 A remote MCP server on Cloudflare Workers that gives LLMs persistent, structured memory via knowledge graphs, semantic search, and temporally-decayed recall.
 


### PR DESCRIPTION
## Summary

- Add job summaries to the two workflows that were missing them
- Auto-update CHANGELOG.md when commits land on main
- Bump all GitHub Actions to latest versions

## Changes

### Job summaries
- **`release.yml`** — shows previous/new version, bump type, release link
- **`opencode.yml`** — shows trigger user, command, PR number, skip reason if applicable

### Auto-changelog (`changelog.yml`)
- Runs on every push to main (except CHANGELOG.md-only changes)
- Regenerates CHANGELOG.md via git-cliff
- Commits and pushes if changed (`docs: update changelog [skip ci]`)
- Prevents infinite loops via author check + paths-ignore

### Action version bumps
| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 (mixed with v6) | v6 everywhere |
| `actions/setup-node` | v4 | v6 |