### PR TITLE
fix: batch reindex_vectors + enforce strict namespace ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ A remote MCP server on Cloudflare Workers that gives LLMs persistent, structured
 | Cache            | **KV**                         | Optional caching layer                                           |
 | Blob storage     | **R2**                         | Conversation logs, documents                                     |
 
-## Tools (13)
+## Tools (14)
 
-Consolidated from 25 granular tools into 13 action-based tools for token efficiency. Each multi-action tool uses an `action` or `mode` parameter to select the operation.
+Consolidated from 25 granular tools into 14 action-based tools for token efficiency. Each multi-action tool uses an `action` or `mode` parameter to select the operation.
 
 **Namespaces** -- `manage_namespace` (create, list)
 
@@ -41,7 +41,7 @@ Consolidated from 25 granular tools into 13 action-based tools for token efficie
 
 **Semantic search** -- `search` (modes: semantic vector search, context with graph enrichment)
 
-**Admin** -- `reindex_vectors` (re-embed all entities/memories into Vectorize)
+**Admin** -- `reindex_vectors` (re-embed all entities/memories into Vectorize), `claim_namespaces` (adopt unowned legacy namespaces)
 
 ## Project Structure
 
@@ -65,7 +65,7 @@ src/
     memory.ts           manage_memory, query_memories tools
     conversation.ts     manage_conversation, add_message, get_messages tools
     search.ts           search tool (semantic + context modes)
-    admin.ts            reindex_vectors tool
+    admin.ts            reindex_vectors, claim_namespaces tools
   graph/
     namespaces.ts       Namespace D1 CRUD
     entities.ts         Entity D1 CRUD

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,8 +2,8 @@
  * Per-user authorization helpers.
  *
  * Namespaces have an `owner` column (email). These helpers enforce that the
- * authenticated user can only access namespaces they own (or legacy unowned
- * namespaces where owner IS NULL).
+ * authenticated user can only access namespaces they own. Unowned namespaces
+ * must be claimed via the claim_namespaces admin action before use.
  */
 
 import type { NamespaceRow } from "./types.js";
@@ -17,7 +17,7 @@ export class AccessDeniedError extends Error {
 
 /**
  * Verify the authenticated user owns the given namespace.
- * Allows access to unowned (legacy) namespaces where owner IS NULL.
+ * Unowned namespaces (owner IS NULL) are inaccessible — claim them first.
  */
 export async function assertNamespaceAccess(
   db: D1Database,
@@ -33,7 +33,7 @@ export async function assertNamespaceAccess(
     throw new AccessDeniedError("Namespace not found");
   }
 
-  if (ns.owner !== null && ns.owner !== email) {
+  if (ns.owner !== email) {
     throw new AccessDeniedError("You do not have access to this namespace");
   }
 

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -18,6 +18,16 @@ export async function embed(ai: Ai, text: string): Promise<number[]> {
 }
 
 /**
+ * Generate embedding vectors for multiple texts in a single Workers AI call.
+ * Much more efficient than calling embed() in a loop.
+ */
+export async function embedBatch(ai: Ai, texts: string[]): Promise<number[][]> {
+  if (texts.length === 0) return [];
+  const result = (await ai.run(EMBEDDING_MODEL, { text: texts })) as { data: number[][] };
+  return result.data;
+}
+
+/**
  * Upsert a vector for an entity into Vectorize.
  */
 export async function upsertEntityVector(

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -1,5 +1,10 @@
 /** Barrel export for graph operations. */
-export { createNamespace, getNamespace, listNamespaces } from "./namespaces.js";
+export {
+  createNamespace,
+  getNamespace,
+  listNamespaces,
+  claimUnownedNamespaces,
+} from "./namespaces.js";
 export { createEntity, getEntity, searchEntities, updateEntity, deleteEntity } from "./entities.js";
 export { createRelation, getRelationsFrom, getRelationsTo, deleteRelation } from "./relations.js";
 export { traverse } from "./traversal.js";

--- a/src/graph/namespaces.ts
+++ b/src/graph/namespaces.ts
@@ -29,7 +29,7 @@ export async function getNamespace(db: D1Database, id: string): Promise<Namespac
 export async function listNamespaces(db: D1Database, owner?: string): Promise<NamespaceRow[]> {
   if (owner) {
     const result = await db
-      .prepare(`SELECT * FROM namespaces WHERE owner = ? OR owner IS NULL ORDER BY created_at DESC`)
+      .prepare(`SELECT * FROM namespaces WHERE owner = ? ORDER BY created_at DESC`)
       .bind(owner)
       .all<NamespaceRow>();
     return result.results;
@@ -38,4 +38,16 @@ export async function listNamespaces(db: D1Database, owner?: string): Promise<Na
     .prepare(`SELECT * FROM namespaces ORDER BY created_at DESC`)
     .all<NamespaceRow>();
   return result.results;
+}
+
+/**
+ * Claim all unowned namespaces (owner IS NULL) for the given owner.
+ * Returns the number of namespaces claimed.
+ */
+export async function claimUnownedNamespaces(db: D1Database, owner: string): Promise<number> {
+  const result = await db
+    .prepare(`UPDATE namespaces SET owner = ? WHERE owner IS NULL`)
+    .bind(owner)
+    .run();
+  return result.meta.changes ?? 0;
 }

--- a/src/tools/admin.ts
+++ b/src/tools/admin.ts
@@ -1,10 +1,85 @@
-/** Tool registration: reindex_vectors */
+/** Tool registration: admin tools (reindex_vectors, claim_namespaces) */
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { Env } from "../types.js";
-import * as embeddings from "../embeddings.js";
+import { embedBatch } from "../embeddings.js";
 import { assertNamespaceAccess } from "../auth.js";
-import { txt } from "../response-helpers.js";
+import { claimUnownedNamespaces } from "../graph/namespaces.js";
+import { txt, ok } from "../response-helpers.js";
+
+/** Items per Workers AI + Vectorize batch. Keeps each call well within limits. */
+const BATCH_SIZE = 25;
+
+interface EntityItem {
+  id: string;
+  namespace_id: string;
+  name: string;
+  type: string;
+  summary: string | null;
+}
+
+interface MemoryItem {
+  id: string;
+  namespace_id: string;
+  content: string;
+  type: string;
+}
+
+/**
+ * Process a chunk of entities: batch-embed then batch-upsert into Vectorize.
+ * Returns [successCount, errorCount].
+ */
+async function reindexEntityChunk(env: Env, chunk: EntityItem[]): Promise<[number, number]> {
+  const texts = chunk.map((e) => [e.name, e.type, e.summary].filter(Boolean).join(" | "));
+  const vectors = await embedBatch(env.AI, texts);
+
+  const entries: VectorizeVector[] = chunk.map((e, i) => ({
+    id: `entity:${e.id}`,
+    values: vectors[i],
+    metadata: {
+      kind: "entity",
+      entity_id: e.id,
+      namespace_id: e.namespace_id,
+      name: e.name,
+      type: e.type,
+    },
+  }));
+
+  await env.VECTORIZE.upsert(entries);
+  return [chunk.length, 0];
+}
+
+/**
+ * Process a chunk of memories: batch-embed then batch-upsert into Vectorize.
+ * Returns [successCount, errorCount].
+ */
+async function reindexMemoryChunk(env: Env, chunk: MemoryItem[]): Promise<[number, number]> {
+  const texts = chunk.map((m) => m.content);
+  const vectors = await embedBatch(env.AI, texts);
+
+  const entries: VectorizeVector[] = chunk.map((m, i) => ({
+    id: `memory:${m.id}`,
+    values: vectors[i],
+    metadata: {
+      kind: "memory",
+      memory_id: m.id,
+      namespace_id: m.namespace_id,
+      type: m.type,
+    },
+  }));
+
+  await env.VECTORIZE.upsert(entries);
+  return [chunk.length, 0];
+}
+
+/** Split an array into chunks of the given size. */
+function chunks<T>(arr: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    result.push(arr.slice(i, i + size));
+  }
+  return result;
+}
 
 export function registerAdminTools(server: McpServer, env: Env, email: string) {
   server.tool(
@@ -22,58 +97,54 @@ export function registerAdminTools(server: McpServer, env: Env, email: string) {
       let memoryCount = 0;
       let errorCount = 0;
 
+      // --- Entities ---
       const entityQuery =
         namespace_id === "all"
-          ? "SELECT e.id, e.namespace_id, e.name, e.type, e.summary FROM entities e JOIN namespaces n ON n.id = e.namespace_id WHERE n.owner = ? OR n.owner IS NULL"
+          ? "SELECT e.id, e.namespace_id, e.name, e.type, e.summary FROM entities e JOIN namespaces n ON n.id = e.namespace_id WHERE n.owner = ?"
           : "SELECT id, namespace_id, name, type, summary FROM entities WHERE namespace_id = ?";
       const entityResult = await env.DB.prepare(entityQuery)
         .bind(namespace_id === "all" ? email : namespace_id)
-        .all<{
-          id: string;
-          namespace_id: string;
-          name: string;
-          type: string;
-          summary: string | null;
-        }>();
+        .all<EntityItem>();
 
-      for (const entity of entityResult.results) {
+      for (const chunk of chunks(entityResult.results, BATCH_SIZE)) {
         try {
-          await embeddings.upsertEntityVector(env, {
-            entity_id: entity.id,
-            namespace_id: entity.namespace_id,
-            name: entity.name,
-            type: entity.type,
-            summary: entity.summary,
-          });
-          entityCount++;
+          const [ok] = await reindexEntityChunk(env, chunk);
+          entityCount += ok;
         } catch {
-          errorCount++;
+          errorCount += chunk.length;
         }
       }
 
+      // --- Memories ---
       const memoryQuery =
         namespace_id === "all"
-          ? "SELECT m.id, m.namespace_id, m.content, m.type FROM memories m JOIN namespaces n ON n.id = m.namespace_id WHERE n.owner = ? OR n.owner IS NULL"
+          ? "SELECT m.id, m.namespace_id, m.content, m.type FROM memories m JOIN namespaces n ON n.id = m.namespace_id WHERE n.owner = ?"
           : "SELECT id, namespace_id, content, type FROM memories WHERE namespace_id = ?";
       const memoryResult = await env.DB.prepare(memoryQuery)
         .bind(namespace_id === "all" ? email : namespace_id)
-        .all<{ id: string; namespace_id: string; content: string; type: string }>();
+        .all<MemoryItem>();
 
-      for (const memory of memoryResult.results) {
+      for (const chunk of chunks(memoryResult.results, BATCH_SIZE)) {
         try {
-          await embeddings.upsertMemoryVector(env, {
-            memory_id: memory.id,
-            namespace_id: memory.namespace_id,
-            content: memory.content,
-            type: memory.type,
-          });
-          memoryCount++;
+          const [ok] = await reindexMemoryChunk(env, chunk);
+          memoryCount += ok;
         } catch {
-          errorCount++;
+          errorCount += chunk.length;
         }
       }
 
       return txt({ entities: entityCount, memories: memoryCount, errors: errorCount });
+    },
+  );
+
+  server.tool(
+    "claim_namespaces",
+    "Claim all unowned namespaces for the logged-in user. Run once to adopt legacy data.",
+    {},
+    async () => {
+      const claimed = await claimUnownedNamespaces(env.DB, email);
+      if (claimed === 0) return ok("No unowned namespaces found.");
+      return txt({ claimed, owner: email });
     },
   );
 }


### PR DESCRIPTION
## Summary

Two related fixes to the admin/auth layer:

### 1. Batch reindex_vectors to avoid waitUntil() timeout
- Replaces sequential per-item embed+upsert calls with batched processing
- Adds `embedBatch()` to `src/embeddings.ts` — sends multiple texts to Workers AI in a single call
- Chunks items into batches of 25 — each batch makes **1 Workers AI call + 1 Vectorize upsert**
- Reduces ~298 sequential network round-trips to ~12 for 149 items

### 2. Enforce strict namespace ownership
- **Removes `OR owner IS NULL` fallback** from all queries — unowned namespaces are no longer accessible to any authenticated user
- `assertNamespaceAccess` now rejects if `owner !== email` (previously allowed `owner IS NULL`)
- `listNamespaces` only returns namespaces where `owner = email` (no longer includes unowned)
- `reindex_vectors` "all" mode only processes namespaces owned by the user

### 3. New `claim_namespaces` tool
- Lets the logged-in user adopt all unowned (legacy) namespaces in one call
- Sets `owner = email` on all rows where `owner IS NULL`
- **Run this once after deploying** to claim your existing data

## Files changed

| File | What changed |
|---|---|
| `src/auth.ts` | Strict ownership check — reject `owner IS NULL` |
| `src/graph/namespaces.ts` | Remove `OR owner IS NULL` from list, add `claimUnownedNamespaces()` |
| `src/graph/index.ts` | Export `claimUnownedNamespaces` |
| `src/embeddings.ts` | Add `embedBatch()` for batch embedding |
| `src/tools/admin.ts` | Batched reindex + new `claim_namespaces` tool |
| `README.md` | Tool count 13 → 14, document `claim_namespaces` |

## Migration note

After merging, **run `claim_namespaces` once** via your MCP client to adopt any existing unowned namespaces. Until claimed, legacy data will be inaccessible.