### PR TITLE
docs: tighten documentation, fix inaccuracies, remove fluff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Code is organized into focused modules with a 250-line cap per file:
 - `src/tools/` — One file per tool domain (namespace, entity, relation, traversal, memory, conversation, search, admin). Each exports a `register*Tools(server, env, email)` function.
 - `src/graph/` — D1 operations split by domain (namespaces, entities, relations, traversal) with barrel re-export via `index.ts`.
 - `src/oauth/` — OAuth utilities split by concern (error, sanitize, csrf, state, approval) with barrel re-export via `index.ts`.
-- `schemas/schema.sql` — D1 schema (6 tables: namespaces, entities, relations, conversations, messages, memories + memory_entity_links).
+- `schemas/schema.sql` — D1 schema (7 tables: namespaces, entities, relations, conversations, messages, memories, memory_entity_links).
 
 ### MCP tools (14 total)
 

--- a/README.md
+++ b/README.md
@@ -12,75 +12,56 @@
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/FlarelyLegal/memory-mcp)
 
-Persistent structured memory for LLMs — knowledge graphs, semantic search, and temporally-decayed recall.
+Remote MCP server on Cloudflare Workers providing LLMs with persistent structured memory — knowledge graphs, semantic search, and temporally-decayed recall.
 
 ## Architecture
 
-| Component        | Cloudflare Service             | Purpose                                                          |
-| ---------------- | ------------------------------ | ---------------------------------------------------------------- |
-| MCP sessions     | **Durable Objects**            | Stateful per-session MCP agent (`McpAgent`)                      |
-| Structured graph | **D1** (SQLite)                | Entities, relations, memories, conversations                     |
-| Semantic search  | **Vectorize** + **Workers AI** | Embedding-based similarity (`@cf/baai/bge-large-en-v1.5`, 1024d) |
-| Auth             | **KV** + **OAuthProvider**     | OAuth token/client storage, Cloudflare Access integration        |
-| Cache            | **KV**                         | Optional caching layer                                           |
-| Blob storage     | **R2**                         | Conversation logs, documents                                     |
+| Component        | Cloudflare Service             | Purpose                                             |
+| ---------------- | ------------------------------ | --------------------------------------------------- |
+| MCP sessions     | **Durable Objects**            | Stateful per-session MCP agent                      |
+| Structured graph | **D1** (SQLite)                | Entities, relations, memories, conversations        |
+| Semantic search  | **Vectorize** + **Workers AI** | Embeddings via `@cf/baai/bge-large-en-v1.5` (1024d) |
+| Auth state       | **KV**                         | OAuth tokens/clients, Cloudflare Access integration |
+| Blob storage     | **R2**                         | Reserved for future use                             |
 
 ## Tools (14)
 
-Consolidated from 25 granular tools into 14 action-based tools for token efficiency. Each multi-action tool uses an `action` or `mode` parameter to select the operation.
+**Namespaces** — `manage_namespace` (create, list)
 
-**Namespaces** -- `manage_namespace` (create, list)
+**Entities** — `manage_entity` (create, get, update, delete), `find_entities` (name/type/keyword search)
 
-**Entities** (graph nodes) -- `manage_entity` (create, get, update, delete), `find_entities` (search by name/type/keyword)
+**Relations** — `manage_relation` (create, delete), `get_relations` (from/to/both)
 
-**Relations** (graph edges) -- `manage_relation` (create, delete), `get_relations` (from/to/both with direction filter)
+**Traversal** — `traverse_graph` (BFS, max depth 5)
 
-**Graph traversal** -- `traverse_graph` (BFS from a starting entity, max depth 5)
+**Memories** — `manage_memory` (create, update, delete), `query_memories` (recall, search, entity modes)
 
-**Memories** (knowledge fragments) -- `manage_memory` (create, update, delete), `query_memories` (modes: recall, search, entity)
+**Conversations** — `manage_conversation` (create, list), `add_message`, `get_messages` (recent or search)
 
-**Conversations** -- `manage_conversation` (create, list), `add_message`, `get_messages` (recent or keyword search)
+**Search** — `search` (semantic vector search; context mode enriches with graph neighbors)
 
-**Semantic search** -- `search` (modes: semantic vector search, context with graph enrichment)
-
-**Admin** -- `reindex_vectors` (re-embed all entities/memories into Vectorize), `claim_namespaces` (adopt unowned legacy namespaces)
+**Admin** — `reindex_vectors` (batch re-embed into Vectorize), `claim_namespaces` (adopt unowned namespaces)
 
 ## Project Structure
 
 ```
 src/
-  index.ts              MCP server entry point (McpAgent + OAuthProvider)
-  response-helpers.ts   Shared response utilities (txt, ok, cap)
-  types.ts              TypeScript type definitions
-  utils.ts              Utility functions (IDs, timestamps, decay scoring)
+  index.ts              MCP server entry (McpAgent + OAuthProvider)
+  version.ts            Version, name, description constants
+  types.ts              Env, AuthProps, domain + DB row types
   auth.ts               Per-user namespace authorization guards
-  embeddings.ts         Vectorize + Workers AI embedding operations
+  access-handler.ts     OAuth routes (/authorize, /callback, /health, /)
+  jwt.ts                JWT verification (RSA + expiry + audience)
+  embeddings.ts         Vectorize + Workers AI operations
   memories.ts           Memory CRUD with temporal decay
-  conversations.ts      Conversation and message operations
-  access-handler.ts     Cloudflare Access OAuth route handler
-  jwt.ts                JWT parsing, JWKS fetch, token verification
-  tools/
-    namespace.ts        manage_namespace tool
-    entity.ts           manage_entity, find_entities tools
-    relation.ts         manage_relation, get_relations tools
-    traversal.ts        traverse_graph tool
-    memory.ts           manage_memory, query_memories tools
-    conversation.ts     manage_conversation, add_message, get_messages tools
-    search.ts           search tool (semantic + context modes)
-    admin.ts            reindex_vectors, claim_namespaces tools
-  graph/
-    namespaces.ts       Namespace D1 CRUD
-    entities.ts         Entity D1 CRUD
-    relations.ts        Relation D1 CRUD
-    traversal.ts        BFS graph traversal
-    index.ts            Barrel re-export
-  oauth/
-    error.ts            OAuthError class
-    sanitize.ts         HTML/URL sanitization
-    csrf.ts             CSRF token generation/validation
-    state.ts            OAuth state management + upstream token exchange
-    approval.ts         Approval dialog UI + signed cookie management
-    index.ts            Barrel re-export
+  conversations.ts      Conversation + message operations
+  response-helpers.ts   MCP response helpers (txt, ok, cap)
+  utils.ts              ID generation, decay scoring, JSON helpers
+  tools/                One file per domain, each exports register*Tools()
+  graph/                D1 operations by domain (barrel via index.ts)
+  oauth/                OAuth utilities by concern (barrel via index.ts)
+schemas/
+  schema.sql            D1 schema (7 tables)
 ```
 
 ## Setup
@@ -88,18 +69,15 @@ src/
 ### Prerequisites
 
 - Node.js 24+
-- Cloudflare account with Workers, D1, Vectorize, and Workers AI enabled
+- Cloudflare account with Workers, D1, Vectorize, and Workers AI
 - [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
 
-### 1. Install dependencies
+### Quick Start
 
 ```bash
 npm install
-```
 
-### 2. Create Cloudflare resources
-
-```bash
+# Create Cloudflare resources
 npx wrangler d1 create memory-graph-mcp-db
 npx wrangler vectorize create memory-graph-mcp-embeddings --dimensions=1024 --metric=cosine
 npx wrangler kv namespace create CACHE
@@ -107,30 +85,22 @@ npx wrangler kv namespace create OAUTH_KV
 npx wrangler r2 bucket create memory-graph-mcp-storage
 ```
 
-### 3. Update wrangler.jsonc
-
-Replace the IDs in `wrangler.jsonc` with the values printed by the commands above:
-
-- `database_id` for D1
-- `id` for each KV namespace
-
-### 4. Initialize the database schema
+Update `wrangler.jsonc` with the resource IDs from the commands above.
 
 ```bash
-npm run db:init        # remote
-npm run db:init:local  # local dev
+# Initialize database and deploy
+npm run deploy:init
+
+# Or for local development
+npm run db:init:local
+npx wrangler dev --local --port 8787
 ```
 
-### 5. Deploy
+### Auth (Cloudflare Access)
 
-```bash
-npm run dev     # local development
-npm run deploy  # production
-```
+The OAuth flow requires secrets — copy `.dev.vars.example` to `.dev.vars` and fill in values from your Cloudflare Access application. Without these, `/health` works but authenticated tool calls will not.
 
 ## Connecting Clients
-
-Add to your MCP client config (Claude Desktop, OpenCode, Cursor, etc.):
 
 ```json
 {
@@ -142,19 +112,20 @@ Add to your MCP client config (Claude Desktop, OpenCode, Cursor, etc.):
 }
 ```
 
-Test with the MCP Inspector:
+Works with Claude Desktop, OpenCode, Cursor, or any MCP-compatible client.
 
 ```bash
+# Test with MCP Inspector
 npx @modelcontextprotocol/inspector https://memory-graph-mcp.<your-subdomain>.workers.dev/mcp
 ```
 
 ## Temporal Decay
 
-`query_memories` (recall mode) ranks memories by blending importance with recency:
+`query_memories` recall mode ranks by blending importance with recency:
 
 ```
-relevance = importance * 0.4 + recency_factor * 0.6
-recency_factor = e^(-ln(2) / half_life_hours * age_hours)
+relevance = importance * 0.4 + recency * 0.6
+recency   = e^(-ln(2) / half_life * age_hours)
 ```
 
-Default half-life is 7 days. Accessing a memory resets its recency.
+Default half-life: 7 days. Accessing a memory resets its recency.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -54,7 +54,7 @@
     },
   ],
 
-  // R2 bucket for blob storage (conversation logs, documents, etc.)
+  // R2 bucket for blob storage (reserved for future use)
   "r2_buckets": [
     {
       "binding": "STORAGE",


### PR DESCRIPTION
## Summary

- Fix AGENTS.md table count: 7 tables not 6
- Rewrite README: remove historical fluff ("consolidated from 25 tools"), drop redundant sub-headings in setup, collapse project structure to directory level, add missing `version.ts`, correct R2 purpose (unused, not "conversation logs")
- Fix wrangler.jsonc R2 comment: "reserved for future use" (binding exists but `env.STORAGE` is never referenced)
- Correct KV architecture description: only OAUTH_KV is used (`env.CACHE` is never referenced)

Net: -29 lines across docs while improving accuracy.