### PR TITLE
feat: add GitHub issue templates and dynamic badges

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: Bug Report
+description: Report a bug with the MCP server or a specific tool
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill out the details below.
+
+  - type: dropdown
+    id: tool
+    attributes:
+      label: Tool
+      description: Which tool is affected?
+      options:
+        - manage_namespace
+        - manage_entity
+        - find_entities
+        - manage_relation
+        - get_relations
+        - traverse_graph
+        - manage_memory
+        - query_memories
+        - manage_conversation
+        - add_message
+        - get_messages
+        - search
+        - reindex_vectors
+        - claim_namespaces
+        - Auth / OAuth flow
+        - Server startup / connectivity
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug and what you expected instead.
+      placeholder: Tell us what went wrong...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Call tool '...' with input '...'
+        2. Observe response '...'
+        3. Expected '...'
+    validations:
+      required: false
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      description: Where is this running?
+      options:
+        - Cloudflare Workers (deployed)
+        - Local dev (wrangler dev --local)
+        - MCP Inspector
+    validations:
+      required: true
+
+  - type: dropdown
+    id: client
+    attributes:
+      label: MCP Client
+      description: Which client are you connecting with?
+      options:
+        - Claude Desktop
+        - OpenCode
+        - Cursor
+        - MCP Inspector
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Error Output
+      description: Paste any relevant error messages or logs.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: MCP Documentation
+    url: https://modelcontextprotocol.io
+    about: Learn about the Model Context Protocol.
+  - name: Cloudflare Workers Docs
+    url: https://developers.cloudflare.com/workers/
+    about: Cloudflare Workers platform documentation.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature Request
+description: Suggest a new tool, enhancement, or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea to improve the server? We'd love to hear it.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: What part of the server does this relate to?
+      options:
+        - Graph (entities, relations, traversal)
+        - Memory (storage, recall, decay)
+        - Conversations (messages, history)
+        - Search (semantic, vector, context)
+        - Auth / OAuth
+        - Admin tooling
+        - New tool
+        - Deployment / infrastructure
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What would you like to see added or changed?
+      placeholder: Describe your idea...
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Why would this be useful? What problem does it solve?
+      placeholder: Explain the scenario...
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Possible Implementation
+      description: Any ideas on how this could work? (optional)
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@
 <!-- badges:start -->
 
 [![CI](https://github.com/FlarelyLegal/memory-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/FlarelyLegal/memory-mcp/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/FlarelyLegal/memory-mcp?logo=github&label=release)](https://github.com/FlarelyLegal/memory-mcp/releases/latest)
 [![Node.js](https://img.shields.io/badge/Node.js-≥24-5FA04E?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)](https://developers.cloudflare.com/workers/)
 [![MCP SDK](https://img.shields.io/badge/MCP_SDK-1.27-blue)](https://modelcontextprotocol.io)
+[![GitHub Issues](https://img.shields.io/github/issues/FlarelyLegal/memory-mcp?logo=github)](https://github.com/FlarelyLegal/memory-mcp/issues)
+[![GitHub Stars](https://img.shields.io/github/stars/FlarelyLegal/memory-mcp?style=flat&logo=github&label=stars)](https://github.com/FlarelyLegal/memory-mcp/stargazers)
 
 <!-- badges:end -->
 


### PR DESCRIPTION
## Summary

- Add structured issue templates (YAML forms) for bug reports and feature requests, adapted for the MCP server context
- Disable blank issues, add contact links to MCP and Cloudflare Workers docs
- Add dynamic shields.io badges: release version, open issues, stars

### Issue Templates

- **Bug Report** — tool dropdown (all 14 tools + auth/connectivity/other), environment dropdown (deployed/local/inspector), MCP client dropdown, logs field with shell rendering
- **Feature Request** ��� area dropdown (graph/memory/conversations/search/auth/admin/new tool/infra), description, use case, optional implementation
- **config.yml** — blank issues disabled, links to MCP and Cloudflare Workers docs

### Badges

- `release` — dynamic from latest GitHub release
- `issues` — dynamic open issue count
- `stars` — dynamic star count