### PR TITLE
feat: add REST API layer with service token auth and OpenAPI docs

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,7 +1,15 @@
-ACCESS_CLIENT_ID=your-cloudflare-access-client-id
-ACCESS_CLIENT_SECRET=your-cloudflare-access-client-secret
+# Cloudflare Access SaaS application (OIDC) — for the MCP OAuth login flow
+ACCESS_CLIENT_ID=your-saas-app-client-id
+ACCESS_CLIENT_SECRET=your-saas-app-client-secret
 ACCESS_TOKEN_URL=https://your-team.cloudflareaccess.com/cdn-cgi/access/sso/oidc/your-app-id/token
 ACCESS_AUTHORIZATION_URL=https://your-team.cloudflareaccess.com/cdn-cgi/access/sso/oidc/your-app-id/authorize
-ACCESS_JWKS_URL=https://your-team.cloudflareaccess.com/cdn-cgi/access/certs
+
+# Cloudflare Access application protecting your Worker's domain
+# Find under: Zero Trust > Access > Applications > your app > Overview
 ACCESS_AUD_TAG=your-access-application-audience-tag
+
+# JWKS endpoint for your team — used to verify JWT signatures
+ACCESS_JWKS_URL=https://your-team.cloudflareaccess.com/cdn-cgi/access/certs
+
+# Random key for encrypting OAuth cookies — generate with: openssl rand -hex 32
 COOKIE_ENCRYPTION_KEY=generate-with-openssl-rand-hex-32

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,11 @@ See `package.json` scripts. Summary:
 - **Security headers:** All responses from the access handler include `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and `Strict-Transport-Security`.
 - **Input validation:** All MCP tool inputs have Zod `.max()` bounds on strings and arrays to prevent oversized payloads to D1/Workers AI.
 - **Relation ownership:** `manage_relation` create verifies both `source_id` and `target_id` belong to the specified namespace — cross-namespace relations are rejected.
+- **REST API auth:** API endpoints at `/api/v1/*` authenticate via JWT from Cloudflare Access. The middleware checks the `Cf-Access-Jwt-Assertion` header first, then falls back to the `CF_Authorization` cookie (Access sets the cookie for service token and browser flows). `/api/docs` and `/api/openapi.json` are unauthenticated.
+- **Service token identity resolution:** Cloudflare Access service token JWTs have no `email` claim and an empty `sub`. Identity is resolved via `common_name` (= `CF-Access-Client-Id`, survives token rotation). The middleware looks up `st:<common_name>` in KV (`env.CACHE`) to get the bound email. Unregistered service tokens get 403. Bind tokens via `POST /api/v1/admin/service-tokens`. No MCP tool for token management — REST API only.
+- **`ACCESS_AUD_TAG` must match an Access application:** This secret must be the audience tag from the Cloudflare Access application protecting your Worker's domain. Mismatched audience tags cause `Invalid or expired token` errors on otherwise valid JWTs.
+- **OpenAPI spec is auto-generated:** Each route file registers both its handler and its OpenAPI `PathOperation`. The spec at `/api/openapi.json` is assembled dynamically — no separate spec file to maintain.
+- **CORS:** All `/api/*` responses include permissive CORS headers (`Access-Control-Allow-Origin: *`).
 
 ### File structure
 
@@ -51,7 +56,7 @@ Code is organized into focused modules with a 250-line cap per file:
 - `src/index.ts` — MCP server entry point (McpAgent class + OAuthProvider export)
 - `src/version.ts` — Single source of truth for version, name, description, repo URL
 - `src/types.ts` — `Env` interface (all bindings), `AuthProps`, domain types + DB row types
-- `src/access-handler.ts` — OAuth route handler (`/authorize`, `/callback`, `/health`, `/`)
+- `src/access-handler.ts` — OAuth route handler (`/authorize`, `/callback`, `/health`, `/`, `/api/*`)
 - `src/auth.ts` — Per-user authorization: `assertNamespaceAccess`, `assertEntityAccess`, `assertMemoryAccess`, `assertConversationAccess`, `assertRelationAccess`
 - `src/jwt.ts` — JWT verification (RSA signature + expiry + audience validation)
 - `src/embeddings.ts` — Vectorize + Workers AI: embed, upsert, delete, semantic search
@@ -59,8 +64,20 @@ Code is organized into focused modules with a 250-line cap per file:
 - `src/conversations.ts` — Conversation and message history
 - `src/utils.ts` — `generateId`, `decayScore`, JSON helpers
 - `src/response-helpers.ts` — Shared MCP response helpers (`txt`, `ok`, `cap`)
+- `src/reindex.ts` — Shared batch-reindex logic (entity/memory chunk embedding + Vectorize upsert) used by both MCP tools and REST API
 - `src/tools/` — One file per tool domain (namespace, entity, relation, traversal, memory, conversation, search, admin). Each exports a `register*Tools(server, env, email)` function.
 - `src/graph/` — D1 operations split by domain (namespaces, entities, relations, traversal) with barrel re-export via `index.ts`.
+- `src/api/` — REST API layer (OpenAPI 3.1 + Scalar docs):
+  - `index.ts` — Router, route registration, CORS, public endpoints (`/api/docs`, `/api/openapi.json`)
+  - `types.ts` — `ApiContext`, `RouteDefinition`, `PathOperation`, `HttpMethod`, OpenAPI schema types
+  - `registry.ts` — Route registry (single source of truth for routing + OpenAPI spec)
+  - `middleware.ts` — JWT auth (`Cf-Access-Jwt-Assertion`), service token → email resolution via KV, JSON helpers, error handler
+  - `service-tokens.ts` — `ST_PREFIX` constant and `ServiceTokenMapping` type (shared by middleware + token routes)
+  - `row-parsers.ts` — `parseEntityRow`, `parseMemoryRow` (shared by collection + CRUD route files)
+  - `openapi.ts` — Assembles OpenAPI 3.1 spec dynamically from registered routes
+  - `schemas.ts` — Shared OpenAPI schema fragments, parameter helpers, `queryLimit()`, enum helpers (`memoryTypeEnum`, `roleEnum`, `metadataSchema`)
+  - `docs.ts` — Scalar API reference UI
+  - `routes/` — One file per domain (namespaces, entities, entity-crud, relations, traversal, memories, memory-queries, conversations, messages, search, admin, tokens, token-crud). Each registers routes + their OpenAPI path definitions.
 - `src/oauth/` — OAuth utilities split by concern (error, sanitize, csrf, state, approval) with barrel re-export via `index.ts`.
 - `schemas/schema.sql` — D1 schema (7 tables: namespaces, entities, relations, conversations, messages, memories, memory_entity_links).
 

--- a/README.md
+++ b/README.md
@@ -24,63 +24,21 @@ Remote MCP server on Cloudflare Workers providing LLMs with persistent structure
 | MCP sessions     | **Durable Objects**            | Stateful per-session MCP agent                      |
 | Structured graph | **D1** (SQLite)                | Entities, relations, memories, conversations        |
 | Semantic search  | **Vectorize** + **Workers AI** | Embeddings via `@cf/baai/bge-large-en-v1.5` (1024d) |
-| Auth state       | **KV**                         | OAuth tokens/clients, Cloudflare Access integration |
+| Auth + tokens    | **KV**                         | OAuth state, service token → email bindings         |
 | Blob storage     | **R2**                         | Reserved for future use                             |
-
-## Tools (14)
-
-**Namespaces** — `manage_namespace` (create, list)
-
-**Entities** — `manage_entity` (create, get, update, delete), `find_entities` (name/type/keyword search)
-
-**Relations** — `manage_relation` (create, delete), `get_relations` (from/to/both)
-
-**Traversal** — `traverse_graph` (BFS, max depth 5)
-
-**Memories** — `manage_memory` (create, update, delete), `query_memories` (recall, search, entity modes)
-
-**Conversations** — `manage_conversation` (create, list), `add_message`, `get_messages` (recent or search)
-
-**Search** — `search` (semantic vector search; context mode enriches with graph neighbors)
-
-**Admin** — `reindex_vectors` (batch re-embed into Vectorize), `claim_namespaces` (adopt unowned namespaces)
-
-## Project Structure
-
-```
-src/
-  index.ts              MCP server entry (McpAgent + OAuthProvider)
-  version.ts            Version, name, description constants
-  types.ts              Env, AuthProps, domain + DB row types
-  auth.ts               Per-user namespace authorization guards
-  access-handler.ts     OAuth routes (/authorize, /callback, /health, /)
-  jwt.ts                JWT verification (RSA + expiry + audience)
-  embeddings.ts         Vectorize + Workers AI operations
-  memories.ts           Memory CRUD with temporal decay
-  conversations.ts      Conversation + message operations
-  response-helpers.ts   MCP response helpers (txt, ok, cap)
-  utils.ts              ID generation, decay scoring, JSON helpers
-  tools/                One file per domain, each exports register*Tools()
-  graph/                D1 operations by domain (barrel via index.ts)
-  oauth/                OAuth utilities by concern (barrel via index.ts)
-schemas/
-  schema.sql            D1 schema (7 tables)
-```
 
 ## Setup
 
 ### Prerequisites
 
-- Node.js 24+
+- Node.js 24+, [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
 - Cloudflare account with Workers, D1, Vectorize, and Workers AI
-- [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
 
-### Quick Start
+### 1. Create Cloudflare resources
 
 ```bash
 npm install
 
-# Create Cloudflare resources
 npx wrangler d1 create memory-graph-mcp-db
 npx wrangler vectorize create memory-graph-mcp-embeddings --dimensions=1024 --metric=cosine
 npx wrangler kv namespace create CACHE
@@ -90,20 +48,69 @@ npx wrangler r2 bucket create memory-graph-mcp-storage
 
 Update `wrangler.jsonc` with the resource IDs from the commands above.
 
-```bash
-# Initialize database and deploy
-npm run deploy:init
+### 2. Configure Cloudflare Access
 
-# Or for local development
-npm run db:init:local
-npx wrangler dev --local --port 8787
+You need a [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/applications/) application to protect your Worker. This provides authentication for both interactive (MCP) and programmatic (REST API) access.
+
+1. In the [Zero Trust dashboard](https://one.dash.cloudflare.com/), go to **Access > Applications**
+2. Create a **Self-hosted** application for your Workers domain (e.g. `memory-graph-mcp.<subdomain>.workers.dev`)
+3. Add an **Allow** policy for your identity provider (Google, GitHub, etc.)
+4. If you plan to use service tokens for programmatic access, also add a **Service Auth** policy
+5. Note the following values from the application configuration:
+
+| Value                          | Where to find it                                           | Used as           |
+| ------------------------------ | ---------------------------------------------------------- | ----------------- |
+| Application Audience (AUD) tag | Application overview page                                  | `ACCESS_AUD_TAG`  |
+| JWKS URL                       | `https://<team>.cloudflareaccess.com/cdn-cgi/access/certs` | `ACCESS_JWKS_URL` |
+
+You also need a **SaaS application** for the MCP OAuth flow (this is separate from the self-hosted app above):
+
+| Value             | Where to find it          | Used as                    |
+| ----------------- | ------------------------- | -------------------------- |
+| Client ID         | SaaS app > OIDC settings  | `ACCESS_CLIENT_ID`         |
+| Client Secret     | SaaS app > OIDC settings  | `ACCESS_CLIENT_SECRET`     |
+| Token URL         | SaaS app > OIDC endpoints | `ACCESS_TOKEN_URL`         |
+| Authorization URL | SaaS app > OIDC endpoints | `ACCESS_AUTHORIZATION_URL` |
+
+### 3. Set secrets
+
+For local development, copy `.dev.vars.example` to `.dev.vars` and fill in the values.
+
+For production, set each secret on the Worker:
+
+```bash
+npx wrangler secret put ACCESS_CLIENT_ID
+npx wrangler secret put ACCESS_CLIENT_SECRET
+npx wrangler secret put ACCESS_TOKEN_URL
+npx wrangler secret put ACCESS_AUTHORIZATION_URL
+npx wrangler secret put ACCESS_JWKS_URL
+npx wrangler secret put ACCESS_AUD_TAG
+npx wrangler secret put COOKIE_ENCRYPTION_KEY   # generate with: openssl rand -hex 32
 ```
 
-### Auth (Cloudflare Access)
+**Important:** `ACCESS_AUD_TAG` must be the audience tag from the Cloudflare Access application protecting your Worker's domain. Mismatched audience tags cause `Invalid or expired token` errors.
 
-The OAuth flow requires secrets — copy `.dev.vars.example` to `.dev.vars` and fill in values from your Cloudflare Access application. Without these, `/health` works but authenticated tool calls will not.
+### 4. Deploy
 
-## Connecting Clients
+```bash
+npm run deploy:init    # first deploy (creates D1 tables + deploys)
+npm run deploy         # subsequent deploys
+```
+
+### Local development
+
+```bash
+npm run db:init:local                  # create local D1 tables
+npx wrangler dev --local --port 8787   # start dev server
+```
+
+Note: Workers AI and Vectorize are unavailable locally. Embedding/search tools fail gracefully. D1, KV, R2, and Durable Objects work.
+
+## Authentication
+
+### Interactive (MCP clients)
+
+For Claude Desktop, Cursor, OpenCode, or any MCP-compatible client:
 
 ```json
 {
@@ -115,14 +122,83 @@ The OAuth flow requires secrets — copy `.dev.vars.example` to `.dev.vars` and 
 }
 ```
 
-Works with Claude Desktop, OpenCode, Cursor, or any MCP-compatible client.
+Your client opens the Cloudflare Access login page. You authenticate with your IdP, and the OAuth flow completes automatically. All data is scoped to your email.
+
+### Programmatic (REST API via service tokens)
+
+For agents, scripts, and CI pipelines that need programmatic access.
+
+**1. Create a service token** in the [Zero Trust dashboard](https://one.dash.cloudflare.com/) under Access > Service Auth > Service Tokens. Save the **Client ID** and **Client Secret** (secret is only shown once).
+
+**2. Add a Service Auth policy** to your Access application (Access > Applications > your app > Policies) that allows the service token.
+
+**3. Bind the token to your email.** Log in to your Worker in a browser, then grab the `CF_Authorization` cookie from DevTools (Application > Cookies). Use it to bind:
 
 ```bash
-# Test with MCP Inspector
-npx @modelcontextprotocol/inspector https://memory-graph-mcp.<your-subdomain>.workers.dev/mcp
+curl -X POST https://<your-worker>/api/v1/admin/service-tokens \
+  -H "Cookie: CF_Authorization=<your-jwt-from-browser>" \
+  -H "Content-Type: application/json" \
+  -d '{"common_name": "<client-id>", "label": "My CI bot"}'
 ```
 
-## Temporal Decay
+**4. Make API calls.** Cloudflare Access validates the service token credentials and injects a signed JWT before the request reaches the Worker:
+
+```bash
+curl https://<your-worker>/api/v1/namespaces \
+  -H "CF-Access-Client-Id: <client-id>" \
+  -H "CF-Access-Client-Secret: <client-secret>"
+```
+
+The Worker resolves the service token to your email via KV. All operations run with your permissions.
+
+### Service token management
+
+| Action           | Method   | Endpoint                                    |
+| ---------------- | -------- | ------------------------------------------- |
+| Bind token       | `POST`   | `/api/v1/admin/service-tokens`              |
+| List your tokens | `GET`    | `/api/v1/admin/service-tokens`              |
+| Get binding      | `GET`    | `/api/v1/admin/service-tokens/:common_name` |
+| Update label     | `PATCH`  | `/api/v1/admin/service-tokens/:common_name` |
+| Revoke           | `DELETE` | `/api/v1/admin/service-tokens/:common_name` |
+
+- `common_name` (= Client ID) survives token rotation — no need to re-bind after rotating the secret in the CF dashboard
+- Unbound service tokens receive 403
+
+### API docs
+
+- **OpenAPI spec:** `GET /api/openapi.json`
+- **Interactive docs:** `GET /api/docs` (Scalar UI)
+- Both endpoints are unauthenticated.
+
+### Public endpoints (no auth)
+
+| Endpoint                | Response                                                      |
+| ----------------------- | ------------------------------------------------------------- |
+| `GET /`                 | Plain-text landing page (version, description, repo)          |
+| `GET /health`           | `{"status":"ok","server":"memory-graph-mcp","version":"..."}` |
+| `GET /api/docs`         | Scalar API reference UI                                       |
+| `GET /api/openapi.json` | OpenAPI 3.1 spec                                              |
+
+## MCP Tools (14)
+
+| Tool                  | Description                                                |
+| --------------------- | ---------------------------------------------------------- |
+| `manage_namespace`    | Create or list memory namespaces                           |
+| `manage_entity`       | CRUD for graph entities with embedding upsert              |
+| `find_entities`       | Search entities by name/type/keyword                       |
+| `manage_relation`     | Create or delete directed relations (with ownership check) |
+| `get_relations`       | Query relations from/to an entity                          |
+| `traverse_graph`      | BFS from an entity up to max_depth hops                    |
+| `manage_memory`       | Create/update/delete memories with embedding               |
+| `query_memories`      | Recall (decay-ranked), search (keyword), or entity-linked  |
+| `manage_conversation` | Create or list conversations                               |
+| `add_message`         | Add a message and embed for search                         |
+| `get_messages`        | Get or search messages                                     |
+| `search`              | Semantic vector search; context mode enriches with graph   |
+| `reindex_vectors`     | Batch re-embed entities/memories (25 per batch)            |
+| `claim_namespaces`    | Claim all unowned namespaces for current user              |
+
+### Temporal decay
 
 `query_memories` recall mode ranks by blending importance with recency:
 

--- a/src/access-handler.ts
+++ b/src/access-handler.ts
@@ -1,11 +1,12 @@
 /**
  * Cloudflare Access OAuth handler.
- * Handles /authorize, POST /authorize, and /callback routes to bridge
+ * Handles /authorize, POST /authorize, /callback, and /api/* routes to bridge
  * the MCP OAuth flow with Cloudflare Access as the upstream IdP.
  */
 import type { AuthRequest } from "@cloudflare/workers-oauth-provider";
 
 import type { Env, AuthProps } from "./types.js";
+import { handleApiRequest } from "./api/index.js";
 import {
   addApprovedClient,
   createOAuthState,
@@ -177,6 +178,11 @@ async function handleRequest(
     });
 
     return Response.redirect(redirectTo, 302);
+  }
+
+  // REST API — /api/* routes handled by the API layer
+  if (pathname.startsWith("/api/") || pathname === "/api") {
+    return handleApiRequest(request, env);
   }
 
   if (pathname === "/health") {

--- a/src/api/docs.ts
+++ b/src/api/docs.ts
@@ -1,0 +1,21 @@
+/** Scalar API reference UI served at /api/docs. */
+
+/** Returns an HTML page that loads Scalar's API reference component. */
+export function renderScalarDocs(specUrl: string): Response {
+  const html = `<!doctype html>
+<html>
+<head>
+  <title>Memory Graph API</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
+  <script id="api-reference" data-url="${specUrl}"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+</body>
+</html>`;
+
+  return new Response(html, {
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,115 @@
+/**
+ * REST API entry point — router, route registration, and public endpoints.
+ *
+ * All route modules self-register via the registry when imported. The router
+ * matches incoming requests against registered routes, authenticates, and
+ * dispatches to the handler.
+ */
+import type { Env } from "../types.js";
+import type { HttpMethod } from "./types.js";
+import { matchRoute } from "./registry.js";
+import { authenticate, json, jsonError } from "./middleware.js";
+import { buildOpenApiSpec } from "./openapi.js";
+import { renderScalarDocs } from "./docs.js";
+
+// Import route modules — side effect: registers routes in the registry.
+import { registerNamespaceRoutes } from "./routes/namespaces.js";
+import { registerEntityRoutes } from "./routes/entities.js";
+import { registerEntityCrudRoutes } from "./routes/entity-crud.js";
+import { registerRelationRoutes } from "./routes/relations.js";
+import { registerTraversalRoutes } from "./routes/traversal.js";
+import { registerMemoryRoutes } from "./routes/memories.js";
+import { registerMemoryQueryRoutes } from "./routes/memory-queries.js";
+import { registerConversationRoutes } from "./routes/conversations.js";
+import { registerMessageRoutes } from "./routes/messages.js";
+import { registerSearchRoutes } from "./routes/search.js";
+import { registerAdminRoutes } from "./routes/admin.js";
+import { registerTokenRoutes } from "./routes/tokens.js";
+import { registerTokenCrudRoutes } from "./routes/token-crud.js";
+
+// Register all route modules once at module load time.
+let registered = false;
+function ensureRegistered(): void {
+  if (registered) return;
+  registered = true;
+  registerNamespaceRoutes();
+  registerEntityRoutes();
+  registerEntityCrudRoutes();
+  registerRelationRoutes();
+  registerTraversalRoutes();
+  registerMemoryRoutes();
+  registerMemoryQueryRoutes();
+  registerConversationRoutes();
+  registerMessageRoutes();
+  registerSearchRoutes();
+  registerAdminRoutes();
+  registerTokenRoutes();
+  registerTokenCrudRoutes();
+}
+
+/**
+ * Handle an incoming /api/* request.
+ * Called from access-handler.ts for any request whose pathname starts with /api/.
+ */
+export async function handleApiRequest(request: Request, env: Env): Promise<Response> {
+  ensureRegistered();
+  const url = new URL(request.url);
+  const { pathname } = url;
+
+  // --- Public endpoints (no auth) ---
+
+  if (pathname === "/api/openapi.json" && request.method === "GET") {
+    const serverUrl = `${url.protocol}//${url.host}`;
+    return json(buildOpenApiSpec(serverUrl));
+  }
+
+  if (pathname === "/api/docs" && request.method === "GET") {
+    const specUrl = `${url.protocol}//${url.host}/api/openapi.json`;
+    return renderScalarDocs(specUrl);
+  }
+
+  // --- CORS preflight ---
+
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders() });
+  }
+
+  // --- Route matching ---
+
+  const matched = matchRoute(request.method as HttpMethod, pathname);
+  if (!matched) {
+    return jsonError("Not found", 404);
+  }
+
+  const { route, params } = matched;
+
+  // --- Auth (skip for explicitly public routes) ---
+
+  if (!route.public) {
+    const result = await authenticate(request, env);
+    if (result instanceof Response) return withCors(result);
+
+    const ctx = { env, email: result, params, query: url.searchParams };
+    return withCors(await route.handler(ctx, request));
+  }
+
+  const ctx = { env, email: "", params, query: url.searchParams };
+  return withCors(await route.handler(ctx, request));
+}
+
+function corsHeaders(): Record<string, string> {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization, Cf-Access-Jwt-Assertion",
+    "Access-Control-Max-Age": "86400",
+  };
+}
+
+function withCors(response: Response): Response {
+  const patched = new Response(response.body, response);
+  for (const [k, v] of Object.entries(corsHeaders())) {
+    patched.headers.set(k, v);
+  }
+  return patched;
+}

--- a/src/api/middleware.ts
+++ b/src/api/middleware.ts
@@ -1,0 +1,114 @@
+/**
+ * API middleware: authentication, JSON helpers, error handling.
+ *
+ * Auth verifies the Cf-Access-Jwt-Assertion header — the signed JWT that
+ * Cloudflare Access injects after validating a user session or service token.
+ *
+ * For human users, the JWT contains an `email` claim (from the IdP).
+ * For service tokens, the JWT has no `email` but includes a `common_name`
+ * claim (equal to the CF-Access-Client-Id). We resolve the service token's
+ * identity via a KV lookup: `st:<common_name>` → `{email, label}`.
+ */
+import type { Env } from "../types.js";
+import { verifyToken } from "../jwt.js";
+import { AccessDeniedError } from "../auth.js";
+import { ST_PREFIX } from "./service-tokens.js";
+import type { ServiceTokenMapping } from "./service-tokens.js";
+
+/** Standard JSON success response. */
+export function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Standard JSON error response. */
+export function jsonError(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * Extract the Access JWT from the request.
+ *
+ * Cloudflare Access provides the JWT in two ways:
+ * - `Cf-Access-Jwt-Assertion` header (preferred, always present for proxied requests)
+ * - `CF_Authorization` cookie (set by Access for browser and service token flows)
+ */
+function extractJwt(request: Request): string | null {
+  const header = request.headers.get("Cf-Access-Jwt-Assertion");
+  if (header) return header;
+
+  const cookie = request.headers.get("Cookie");
+  if (!cookie) return null;
+  const match = cookie.match(/(?:^|;\s*)CF_Authorization=([^\s;]+)/);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Authenticate a request and resolve the user's email.
+ *
+ * 1. Extract JWT from header or cookie.
+ * 2. Verify RSA signature, expiry, and audience.
+ * 3. If JWT has `email` → human user, return it directly.
+ * 4. If JWT has `common_name` but no `email` → service token. Look up
+ *    `st:<common_name>` in KV to resolve the bound email.
+ * 5. If no KV mapping → 403 (unregistered service token).
+ */
+export async function authenticate(request: Request, env: Env): Promise<string | Response> {
+  const jwt = extractJwt(request);
+
+  if (!jwt) {
+    return jsonError("Missing Cf-Access-Jwt-Assertion header", 401);
+  }
+
+  let claims: Record<string, unknown>;
+  try {
+    claims = await verifyToken(env, jwt);
+  } catch {
+    return jsonError("Invalid or expired token", 401);
+  }
+
+  // Human user — JWT contains email from IdP
+  const email = claims.email as string | undefined;
+  if (email) {
+    return email;
+  }
+
+  // Service token — JWT contains common_name (= CF-Access-Client-Id)
+  const commonName = claims.common_name as string | undefined;
+  if (!commonName) {
+    return jsonError("JWT missing email and common_name claims", 401);
+  }
+
+  const mapping = await env.CACHE.get<ServiceTokenMapping>(`${ST_PREFIX}${commonName}`, "json");
+  if (!mapping) {
+    return jsonError("Service token not registered. Bind it to an email first.", 403);
+  }
+
+  return mapping.email;
+}
+
+/** Parse JSON body with error handling. */
+export async function parseBody<T = Record<string, unknown>>(
+  request: Request,
+): Promise<T | Response> {
+  try {
+    return (await request.json()) as T;
+  } catch {
+    return jsonError("Invalid JSON body", 400);
+  }
+}
+
+/** Wrap a handler to catch known errors and return appropriate responses. */
+export function handleError(error: unknown): Response {
+  if (error instanceof AccessDeniedError) {
+    return jsonError(error.message, 403);
+  }
+  // eslint-disable-next-line no-console
+  console.error("API error:", error);
+  return jsonError("Internal server error", 500);
+}

--- a/src/api/openapi.ts
+++ b/src/api/openapi.ts
@@ -1,0 +1,100 @@
+/**
+ * OpenAPI 3.1 spec assembler.
+ *
+ * Builds the full spec dynamically from routes registered in the registry.
+ * Adding a new route with its PathOperation spec automatically updates the
+ * OpenAPI output �� no separate spec file to maintain.
+ */
+import { getRoutes } from "./registry.js";
+import { errorBodySchema } from "./schemas.js";
+import { VERSION, SERVER_DESCRIPTION, REPO_URL } from "../version.js";
+
+/** Common security scheme reference applied to authenticated endpoints. */
+const SECURITY_SCHEME = { CloudflareAccess: [] };
+
+/** Reusable error response schemas. */
+const ERROR_RESPONSES = {
+  "401": {
+    description: "Missing or invalid authentication",
+    content: { "application/json": { schema: errorBodySchema() } },
+  },
+  "403": {
+    description: "Access denied",
+    content: { "application/json": { schema: errorBodySchema() } },
+  },
+  "500": {
+    description: "Internal server error",
+    content: { "application/json": { schema: errorBodySchema() } },
+  },
+};
+
+/** Build the complete OpenAPI 3.1 spec from all registered routes. */
+export function buildOpenApiSpec(serverUrl?: string): Record<string, unknown> {
+  const paths: Record<string, Record<string, unknown>> = {};
+
+  for (const route of getRoutes()) {
+    // Convert Express-style :param to OpenAPI {param}
+    const openApiPath = route.pattern.replace(/:([a-zA-Z_]+)/g, "{$1}");
+    const method = route.method.toLowerCase();
+
+    if (!paths[openApiPath]) {
+      paths[openApiPath] = {};
+    }
+
+    const operation: Record<string, unknown> = { ...route.spec };
+
+    // Add standard error responses to authenticated endpoints
+    if (!route.public) {
+      operation.security = [SECURITY_SCHEME];
+      operation.responses = {
+        ...route.spec.responses,
+        ...ERROR_RESPONSES,
+      };
+    }
+
+    paths[openApiPath][method] = operation;
+  }
+
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "Memory Graph API",
+      description: SERVER_DESCRIPTION,
+      version: VERSION,
+      license: { name: "MIT", url: `${REPO_URL}/blob/main/LICENSE` },
+    },
+    servers: serverUrl ? [{ url: serverUrl }] : [],
+    paths,
+    components: {
+      securitySchemes: {
+        CloudflareAccess: {
+          type: "apiKey",
+          in: "header",
+          name: "Cf-Access-Jwt-Assertion",
+          description:
+            "Cloudflare Access JWT. For service-to-service auth, create a " +
+            "Cloudflare Access Service Token. Access validates the credentials " +
+            "and injects a signed JWT via this header automatically.",
+        },
+      },
+    },
+    tags: buildTags(),
+  };
+}
+
+function buildTags() {
+  const tagMap: Record<string, string> = {
+    Namespaces: "Memory namespace management (scopes for organizing data)",
+    Entities: "Knowledge graph entity CRUD",
+    Relations: "Directed relations between entities",
+    Traversal: "Graph traversal (BFS)",
+    Memories: "Persistent memory fragments with temporal decay",
+    Conversations: "Conversation and message history",
+    Search: "Semantic vector search",
+    Admin: "Administrative operations (reindex, claim)",
+  };
+  return Object.entries(tagMap).map(([name, description]) => ({
+    name,
+    description,
+  }));
+}

--- a/src/api/registry.ts
+++ b/src/api/registry.ts
@@ -1,0 +1,53 @@
+/**
+ * Route registry — collects API route definitions and their OpenAPI specs.
+ *
+ * Each route module calls `register()` to add its routes. The registry is
+ * then used by the router (to match requests) and by the OpenAPI assembler
+ * (to build the spec). Single source of truth for both.
+ */
+import type { RouteDefinition, HttpMethod, PathOperation, ApiContext } from "./types.js";
+
+const routes: RouteDefinition[] = [];
+
+/** Register one API route with its handler and OpenAPI spec. */
+export function register(route: RouteDefinition): void {
+  routes.push(route);
+}
+
+/** Get all registered routes (for the router and OpenAPI assembler). */
+export function getRoutes(): readonly RouteDefinition[] {
+  return routes;
+}
+
+/** Convert an Express-style pattern like `/api/v1/entities/:id` to a regex. */
+function patternToRegex(pattern: string): RegExp {
+  const regexStr = pattern.replace(/:([a-zA-Z_]+)/g, "(?<$1>[^/]+)");
+  return new RegExp(`^${regexStr}$`);
+}
+
+/** Match a request against registered routes. Returns the route + extracted params. */
+export function matchRoute(
+  method: HttpMethod,
+  pathname: string,
+): { route: RouteDefinition; params: Record<string, string> } | null {
+  for (const route of routes) {
+    if (route.method !== method) continue;
+    const regex = patternToRegex(route.pattern);
+    const match = pathname.match(regex);
+    if (match) {
+      return { route, params: match.groups ?? {} };
+    }
+  }
+  return null;
+}
+
+/** Helper to define a route with less boilerplate. */
+export function defineRoute(
+  method: HttpMethod,
+  pattern: string,
+  handler: (ctx: ApiContext, request: Request) => Promise<Response>,
+  spec: PathOperation,
+  options?: { public?: boolean },
+): void {
+  register({ method, pattern, handler, spec, public: options?.public });
+}

--- a/src/api/routes/admin.ts
+++ b/src/api/routes/admin.ts
@@ -1,0 +1,134 @@
+/** Admin REST endpoints + OpenAPI definitions. */
+import { defineRoute } from "../registry.js";
+import { json, jsonError, handleError } from "../middleware.js";
+import { assertNamespaceAccess } from "../../auth.js";
+import { listNamespaces, claimUnownedNamespaces, searchEntities } from "../../graph/index.js";
+import { searchMemories } from "../../memories.js";
+import {
+  REINDEX_BATCH_SIZE,
+  chunks,
+  reindexEntityChunk,
+  reindexMemoryChunk,
+} from "../../reindex.js";
+
+export function registerAdminRoutes(): void {
+  defineRoute(
+    "POST",
+    "/api/v1/admin/reindex",
+    async (ctx, request) => {
+      try {
+        const body = (await request.json()) as { namespace_id?: string };
+        if (!body.namespace_id) return jsonError("namespace_id is required", 400);
+
+        let namespaceIds: string[];
+        if (body.namespace_id === "all") {
+          const owned = await listNamespaces(ctx.env.DB, ctx.email);
+          namespaceIds = owned.map((n) => n.id);
+        } else {
+          await assertNamespaceAccess(ctx.env.DB, body.namespace_id, ctx.email);
+          namespaceIds = [body.namespace_id];
+        }
+
+        let entityCount = 0;
+        let memoryCount = 0;
+        let errorCount = 0;
+
+        for (const nsId of namespaceIds) {
+          const entities = await searchEntities(ctx.env.DB, nsId, { limit: 1000 });
+          for (const batch of chunks(entities, REINDEX_BATCH_SIZE)) {
+            try {
+              entityCount += await reindexEntityChunk(ctx.env, batch);
+            } catch {
+              errorCount += batch.length;
+            }
+          }
+
+          const memories = await searchMemories(ctx.env.DB, nsId, { limit: 1000 });
+          for (const batch of chunks(memories, REINDEX_BATCH_SIZE)) {
+            try {
+              memoryCount += await reindexMemoryChunk(ctx.env, batch);
+            } catch {
+              errorCount += batch.length;
+            }
+          }
+        }
+
+        return json({ entities: entityCount, memories: memoryCount, errors: errorCount });
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Reindex vectors",
+      description: "Re-embed all entities and memories into Vectorize. Use after model changes.",
+      tags: ["Admin"],
+      operationId: "reindexVectors",
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["namespace_id"],
+              properties: {
+                namespace_id: {
+                  type: "string",
+                  description: 'Namespace ID, or "all" for all owned namespaces',
+                },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "200": {
+          description: "Reindex results",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  entities: { type: "integer" },
+                  memories: { type: "integer" },
+                  errors: { type: "integer" },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  );
+
+  defineRoute(
+    "POST",
+    "/api/v1/admin/claim-namespaces",
+    async (ctx) => {
+      try {
+        const claimed = await claimUnownedNamespaces(ctx.env.DB, ctx.email);
+        return json({ claimed, owner: ctx.email });
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Claim namespaces",
+      description: "Claim all unowned namespaces for the authenticated user.",
+      tags: ["Admin"],
+      operationId: "claimNamespaces",
+      responses: {
+        "200": {
+          description: "Claim result",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: { claimed: { type: "integer" }, owner: { type: "string" } },
+              },
+            },
+          },
+        },
+      },
+    },
+  );
+}

--- a/src/api/routes/conversations.ts
+++ b/src/api/routes/conversations.ts
@@ -1,0 +1,98 @@
+/** Conversation REST endpoints + OpenAPI definitions. */
+import { defineRoute } from "../registry.js";
+import { json, parseBody, handleError } from "../middleware.js";
+import { createConversation, listConversations } from "../../conversations.js";
+import { assertNamespaceAccess } from "../../auth.js";
+import {
+  nsPathParam,
+  limitQueryParam,
+  queryLimit,
+  conversationSchema,
+  metadataSchema,
+} from "../schemas.js";
+
+export function registerConversationRoutes(): void {
+  defineRoute(
+    "GET",
+    "/api/v1/namespaces/:namespace_id/conversations",
+    async (ctx) => {
+      try {
+        await assertNamespaceAccess(ctx.env.DB, ctx.params.namespace_id, ctx.email);
+        const limit = queryLimit(ctx.query, 50);
+        const rows = await listConversations(ctx.env.DB, ctx.params.namespace_id, { limit });
+        return json(rows);
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "List conversations",
+      tags: ["Conversations"],
+      operationId: "listConversations",
+      parameters: [nsPathParam(), limitQueryParam(50)],
+      responses: {
+        "200": {
+          description: "Array of conversations",
+          content: {
+            "application/json": { schema: { type: "array", items: conversationSchema() } },
+          },
+        },
+      },
+    },
+  );
+
+  defineRoute(
+    "POST",
+    "/api/v1/namespaces/:namespace_id/conversations",
+    async (ctx, request) => {
+      try {
+        await assertNamespaceAccess(ctx.env.DB, ctx.params.namespace_id, ctx.email);
+        const body = await parseBody<{ title?: string; metadata?: Record<string, unknown> }>(
+          request,
+        );
+        if (body instanceof Response) return body;
+
+        const id = await createConversation(ctx.env.DB, {
+          namespace_id: ctx.params.namespace_id,
+          title: body.title,
+          metadata: body.metadata,
+        });
+        return json({ id, title: body.title ?? null }, 201);
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Create conversation",
+      tags: ["Conversations"],
+      operationId: "createConversation",
+      parameters: [nsPathParam()],
+      requestBody: {
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                title: { type: "string", maxLength: 500 },
+                metadata: metadataSchema(),
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "201": {
+          description: "Created",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: { id: { type: "string" }, title: { type: "string", nullable: true } },
+              },
+            },
+          },
+        },
+      },
+    },
+  );
+}

--- a/src/api/routes/entities.ts
+++ b/src/api/routes/entities.ts
@@ -1,0 +1,143 @@
+/** Entity list + create REST endpoints + OpenAPI definitions. */
+import { defineRoute } from "../registry.js";
+import { json, jsonError, parseBody, handleError } from "../middleware.js";
+import { createEntity, searchEntities } from "../../graph/index.js";
+import { assertNamespaceAccess } from "../../auth.js";
+import { upsertEntityVector } from "../../embeddings.js";
+import {
+  nsPathParam,
+  limitQueryParam,
+  queryLimit,
+  entitySchema,
+  metadataSchema,
+} from "../schemas.js";
+import { parseEntityRow } from "../row-parsers.js";
+
+export function registerEntityRoutes(): void {
+  defineRoute(
+    "GET",
+    "/api/v1/namespaces/:namespace_id/entities",
+    async (ctx) => {
+      try {
+        await assertNamespaceAccess(ctx.env.DB, ctx.params.namespace_id, ctx.email);
+        const query = ctx.query.get("q") ?? undefined;
+        const type = ctx.query.get("type") ?? undefined;
+        const limit = queryLimit(ctx.query, 50);
+        const rows = await searchEntities(ctx.env.DB, ctx.params.namespace_id, {
+          query,
+          type,
+          limit,
+        });
+        return json(rows.map(parseEntityRow));
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "List / search entities",
+      description: "Search entities by name, type, or keyword in a namespace.",
+      tags: ["Entities"],
+      operationId: "listEntities",
+      parameters: [
+        nsPathParam(),
+        { name: "q", in: "query", description: "Search query", schema: { type: "string" } },
+        {
+          name: "type",
+          in: "query",
+          description: "Filter by entity type",
+          schema: { type: "string" },
+        },
+        limitQueryParam(50),
+      ],
+      responses: {
+        "200": {
+          description: "Array of entities",
+          content: {
+            "application/json": { schema: { type: "array", items: entitySchema() } },
+          },
+        },
+      },
+    },
+  );
+
+  defineRoute(
+    "POST",
+    "/api/v1/namespaces/:namespace_id/entities",
+    async (ctx, request) => {
+      try {
+        await assertNamespaceAccess(ctx.env.DB, ctx.params.namespace_id, ctx.email);
+        const body = await parseBody<{
+          name?: string;
+          type?: string;
+          summary?: string;
+          metadata?: Record<string, unknown>;
+        }>(request);
+        if (body instanceof Response) return body;
+        if (!body.name || !body.type) return jsonError("name and type are required", 400);
+
+        const id = await createEntity(ctx.env.DB, {
+          namespace_id: ctx.params.namespace_id,
+          name: body.name,
+          type: body.type,
+          summary: body.summary,
+          metadata: body.metadata,
+        });
+        await upsertEntityVector(ctx.env, {
+          entity_id: id,
+          namespace_id: ctx.params.namespace_id,
+          name: body.name,
+          type: body.type,
+          summary: body.summary ?? null,
+        });
+        return json({ id, name: body.name, type: body.type }, 201);
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Create entity",
+      description: "Create a graph entity and embed it for semantic search.",
+      tags: ["Entities"],
+      operationId: "createEntity",
+      parameters: [nsPathParam()],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["name", "type"],
+              properties: {
+                name: { type: "string", maxLength: 200 },
+                type: {
+                  type: "string",
+                  maxLength: 200,
+                  description: "e.g. person, concept, project",
+                },
+                summary: { type: "string", maxLength: 10000 },
+                metadata: metadataSchema(),
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "201": {
+          description: "Entity created",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  id: { type: "string" },
+                  name: { type: "string" },
+                  type: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  );
+}

--- a/src/api/routes/entity-crud.ts
+++ b/src/api/routes/entity-crud.ts
@@ -1,0 +1,120 @@
+/** Entity get/update/delete REST endpoints. */
+import { defineRoute } from "../registry.js";
+import { json, jsonError, parseBody, handleError } from "../middleware.js";
+import { getEntity, updateEntity, deleteEntity } from "../../graph/index.js";
+import { assertEntityAccess } from "../../auth.js";
+import { upsertEntityVector, deleteVector } from "../../embeddings.js";
+import { idPathParam, entitySchema, okSchema, metadataSchema } from "../schemas.js";
+import { parseEntityRow } from "../row-parsers.js";
+
+export function registerEntityCrudRoutes(): void {
+  defineRoute(
+    "GET",
+    "/api/v1/entities/:id",
+    async (ctx) => {
+      try {
+        await assertEntityAccess(ctx.env.DB, ctx.params.id, ctx.email);
+        const entity = await getEntity(ctx.env.DB, ctx.params.id);
+        if (!entity) return jsonError("Entity not found", 404);
+        return json(parseEntityRow(entity));
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Get entity",
+      tags: ["Entities"],
+      operationId: "getEntity",
+      parameters: [idPathParam("Entity ID")],
+      responses: {
+        "200": {
+          description: "Entity",
+          content: {
+            "application/json": { schema: entitySchema() },
+          },
+        },
+      },
+    },
+  );
+
+  defineRoute(
+    "PUT",
+    "/api/v1/entities/:id",
+    async (ctx, request) => {
+      try {
+        await assertEntityAccess(ctx.env.DB, ctx.params.id, ctx.email);
+        const body = await parseBody<{
+          name?: string;
+          type?: string;
+          summary?: string;
+          metadata?: Record<string, unknown>;
+        }>(request);
+        if (body instanceof Response) return body;
+        await updateEntity(ctx.env.DB, ctx.params.id, body);
+        if (body.name || body.type || body.summary !== undefined) {
+          const updated = await getEntity(ctx.env.DB, ctx.params.id);
+          if (updated) {
+            await upsertEntityVector(ctx.env, {
+              entity_id: ctx.params.id,
+              namespace_id: updated.namespace_id,
+              name: updated.name,
+              type: updated.type,
+              summary: updated.summary,
+            });
+          }
+        }
+        return json({ ok: true });
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Update entity",
+      tags: ["Entities"],
+      operationId: "updateEntity",
+      parameters: [idPathParam("Entity ID")],
+      requestBody: {
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                name: { type: "string", maxLength: 200 },
+                type: { type: "string", maxLength: 200 },
+                summary: { type: "string", maxLength: 10000 },
+                metadata: metadataSchema(),
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "200": { description: "Updated", content: { "application/json": { schema: okSchema() } } },
+      },
+    },
+  );
+
+  defineRoute(
+    "DELETE",
+    "/api/v1/entities/:id",
+    async (ctx) => {
+      try {
+        await assertEntityAccess(ctx.env.DB, ctx.params.id, ctx.email);
+        await deleteEntity(ctx.env.DB, ctx.params.id);
+        await deleteVector(ctx.env, "entity", ctx.params.id);
+        return json({ ok: true });
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Delete entity",
+      tags: ["Entities"],
+      operationId: "deleteEntity",
+      parameters: [idPathParam("Entity ID")],
+      responses: {
+        "200": { description: "Deleted", content: { "application/json": { schema: okSchema() } } },
+      },
+    },
+  );
+}

--- a/src/api/routes/memories.ts
+++ b/src/api/routes/memories.ts
@@ -1,0 +1,215 @@
+/** Memory CRUD REST endpoints + OpenAPI definitions. */
+import { defineRoute } from "../registry.js";
+import { json, jsonError, parseBody, handleError } from "../middleware.js";
+import { createMemory, getMemory, updateMemory, deleteMemory } from "../../memories.js";
+import { assertNamespaceAccess, assertMemoryAccess } from "../../auth.js";
+import { upsertMemoryVector, deleteVector } from "../../embeddings.js";
+import {
+  nsPathParam,
+  idPathParam,
+  memorySchema,
+  okSchema,
+  metadataSchema,
+  memoryTypeEnum,
+} from "../schemas.js";
+import { parseMemoryRow } from "../row-parsers.js";
+import type { MemoryType } from "../../types.js";
+
+export function registerMemoryRoutes(): void {
+  defineRoute(
+    "POST",
+    "/api/v1/namespaces/:namespace_id/memories",
+    async (ctx, request) => {
+      try {
+        await assertNamespaceAccess(ctx.env.DB, ctx.params.namespace_id, ctx.email);
+        const body = await parseBody<{
+          content?: string;
+          type?: string;
+          importance?: number;
+          source?: string;
+          entity_ids?: string[];
+          metadata?: Record<string, unknown>;
+        }>(request);
+        if (body instanceof Response) return body;
+        if (!body.content) return jsonError("content is required", 400);
+
+        const id = await createMemory(ctx.env.DB, {
+          namespace_id: ctx.params.namespace_id,
+          content: body.content,
+          type: body.type as MemoryType | undefined,
+          importance: body.importance,
+          source: body.source,
+          entity_ids: body.entity_ids,
+          metadata: body.metadata,
+        });
+        await upsertMemoryVector(ctx.env, {
+          memory_id: id,
+          namespace_id: ctx.params.namespace_id,
+          content: body.content,
+          type: body.type ?? "fact",
+        });
+        return json({ id, type: body.type ?? "fact" }, 201);
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Create memory",
+      description: "Store a memory fragment and embed it for semantic search.",
+      tags: ["Memories"],
+      operationId: "createMemory",
+      parameters: [nsPathParam()],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["content"],
+              properties: {
+                content: { type: "string", maxLength: 10000 },
+                type: memoryTypeEnum(),
+                importance: { type: "number", minimum: 0, maximum: 1 },
+                source: { type: "string", maxLength: 500 },
+                entity_ids: { type: "array", items: { type: "string" } },
+                metadata: metadataSchema(),
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "201": {
+          description: "Memory created",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: { id: { type: "string" }, type: { type: "string" } },
+              },
+            },
+          },
+        },
+      },
+    },
+  );
+
+  defineRoute(
+    "GET",
+    "/api/v1/memories/:id",
+    async (ctx) => {
+      try {
+        await assertMemoryAccess(ctx.env.DB, ctx.params.id, ctx.email);
+        const row = await getMemory(ctx.env.DB, ctx.params.id);
+        if (!row) return jsonError("Memory not found", 404);
+        return json(parseMemoryRow(row));
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Get memory",
+      tags: ["Memories"],
+      operationId: "getMemory",
+      parameters: [idPathParam("Memory ID")],
+      responses: {
+        "200": {
+          description: "Memory",
+          content: {
+            "application/json": { schema: memorySchema() },
+          },
+        },
+      },
+    },
+  );
+
+  defineRoute(
+    "PUT",
+    "/api/v1/memories/:id",
+    async (ctx, request) => {
+      try {
+        await assertMemoryAccess(ctx.env.DB, ctx.params.id, ctx.email);
+        const body = await parseBody<{
+          content?: string;
+          type?: string;
+          importance?: number;
+          metadata?: Record<string, unknown>;
+        }>(request);
+        if (body instanceof Response) return body;
+        await updateMemory(ctx.env.DB, ctx.params.id, body);
+        if (body.content) {
+          const updated = await getMemory(ctx.env.DB, ctx.params.id);
+          if (updated) {
+            await upsertMemoryVector(ctx.env, {
+              memory_id: ctx.params.id,
+              namespace_id: updated.namespace_id,
+              content: updated.content,
+              type: updated.type,
+            });
+          }
+        }
+        return json({ ok: true });
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Update memory",
+      tags: ["Memories"],
+      operationId: "updateMemory",
+      parameters: [idPathParam("Memory ID")],
+      requestBody: {
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                content: { type: "string", maxLength: 10000 },
+                type: memoryTypeEnum(),
+                importance: { type: "number", minimum: 0, maximum: 1 },
+                metadata: metadataSchema(),
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "200": {
+          description: "Updated",
+          content: {
+            "application/json": { schema: okSchema() },
+          },
+        },
+      },
+    },
+  );
+
+  defineRoute(
+    "DELETE",
+    "/api/v1/memories/:id",
+    async (ctx) => {
+      try {
+        await assertMemoryAccess(ctx.env.DB, ctx.params.id, ctx.email);
+        await deleteMemory(ctx.env.DB, ctx.params.id);
+        await deleteVector(ctx.env, "memory", ctx.params.id);
+        return json({ ok: true });
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Delete memory",
+      tags: ["Memories"],
+      operationId: "deleteMemory",
+      parameters: [idPathParam("Memory ID")],
+      responses: {
+        "200": {
+          description: "Deleted",
+          content: {
+            "application/json": { schema: okSchema() },
+          },
+        },
+      },
+    },
+  );
+}

--- a/src/api/routes/memory-queries.ts
+++ b/src/api/routes/memory-queries.ts
@@ -1,0 +1,105 @@
+/** Memory query REST endpoints (recall, search, entity-linked). */
+import { defineRoute } from "../registry.js";
+import { json, jsonError, handleError } from "../middleware.js";
+import { recallMemories, searchMemories, getMemoriesForEntity } from "../../memories.js";
+import { assertNamespaceAccess, assertEntityAccess } from "../../auth.js";
+import {
+  nsPathParam,
+  idPathParam,
+  limitQueryParam,
+  queryLimit,
+  memorySchema,
+  memoryTypeEnum,
+} from "../schemas.js";
+import { parseMemoryRow } from "../row-parsers.js";
+import type { MemoryType } from "../../types.js";
+
+export function registerMemoryQueryRoutes(): void {
+  defineRoute(
+    "GET",
+    "/api/v1/namespaces/:namespace_id/memories",
+    async (ctx) => {
+      try {
+        await assertNamespaceAccess(ctx.env.DB, ctx.params.namespace_id, ctx.email);
+        const mode = ctx.query.get("mode") ?? "recall";
+        const type = ctx.query.get("type") as MemoryType | undefined;
+        const limit = queryLimit(ctx.query, 50);
+
+        if (mode === "search") {
+          const query = ctx.query.get("q");
+          if (!query) return jsonError("q parameter required for search mode", 400);
+          const rows = await searchMemories(ctx.env.DB, ctx.params.namespace_id, {
+            query,
+            type,
+            limit,
+          });
+          return json(rows.map(parseMemoryRow));
+        }
+        const rows = await recallMemories(ctx.env.DB, ctx.params.namespace_id, { type, limit });
+        return json(rows.map(parseMemoryRow));
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Query memories",
+      description: "Recall (decay-ranked) or search (keyword) memories.",
+      tags: ["Memories"],
+      operationId: "queryMemories",
+      parameters: [
+        nsPathParam(),
+        { name: "mode", in: "query", schema: { type: "string", enum: ["recall", "search"] } },
+        {
+          name: "q",
+          in: "query",
+          description: "Required for search mode",
+          schema: { type: "string" },
+        },
+        {
+          name: "type",
+          in: "query",
+          schema: memoryTypeEnum(),
+        },
+        limitQueryParam(50),
+      ],
+      responses: {
+        "200": {
+          description: "Array of memories",
+          content: {
+            "application/json": { schema: { type: "array", items: memorySchema() } },
+          },
+        },
+      },
+    },
+  );
+
+  defineRoute(
+    "GET",
+    "/api/v1/entities/:id/memories",
+    async (ctx) => {
+      try {
+        await assertEntityAccess(ctx.env.DB, ctx.params.id, ctx.email);
+        const limit = queryLimit(ctx.query, 50);
+        const rows = await getMemoriesForEntity(ctx.env.DB, ctx.params.id, { limit });
+        return json(rows.map(parseMemoryRow));
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Get memories for entity",
+      description: "Get memories linked to a specific entity.",
+      tags: ["Memories"],
+      operationId: "getEntityMemories",
+      parameters: [idPathParam("Entity ID"), limitQueryParam(50)],
+      responses: {
+        "200": {
+          description: "Array of memories",
+          content: {
+            "application/json": { schema: { type: "array", items: memorySchema() } },
+          },
+        },
+      },
+    },
+  );
+}

--- a/src/api/routes/messages.ts
+++ b/src/api/routes/messages.ts
@@ -1,0 +1,165 @@
+/** Message REST endpoints (get, add, search). */
+import { defineRoute } from "../registry.js";
+import { json, jsonError, parseBody, handleError } from "../middleware.js";
+import { addMessage, getMessages, getConversation, searchMessages } from "../../conversations.js";
+import { assertNamespaceAccess, assertConversationAccess } from "../../auth.js";
+import { upsertMessageVector } from "../../embeddings.js";
+import {
+  nsPathParam,
+  idPathParam,
+  limitQueryParam,
+  queryLimit,
+  messageSchema,
+  metadataSchema,
+  roleEnum,
+} from "../schemas.js";
+
+export function registerMessageRoutes(): void {
+  defineRoute(
+    "GET",
+    "/api/v1/conversations/:id/messages",
+    async (ctx) => {
+      try {
+        await assertConversationAccess(ctx.env.DB, ctx.params.id, ctx.email);
+        const limit = queryLimit(ctx.query, 100, 50);
+        const rows = await getMessages(ctx.env.DB, ctx.params.id, { limit });
+        return json(rows);
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Get messages",
+      description: "Get messages from a conversation in chronological order.",
+      tags: ["Conversations"],
+      operationId: "getMessages",
+      parameters: [idPathParam("Conversation ID"), limitQueryParam(100)],
+      responses: {
+        "200": {
+          description: "Array of messages",
+          content: {
+            "application/json": { schema: { type: "array", items: messageSchema() } },
+          },
+        },
+      },
+    },
+  );
+
+  defineRoute(
+    "POST",
+    "/api/v1/conversations/:id/messages",
+    async (ctx, request) => {
+      try {
+        await assertConversationAccess(ctx.env.DB, ctx.params.id, ctx.email);
+        const body = await parseBody<{
+          role?: string;
+          content?: string;
+          metadata?: Record<string, unknown>;
+        }>(request);
+        if (body instanceof Response) return body;
+        if (!body.role || !body.content) return jsonError("role and content are required", 400);
+
+        const msgId = await addMessage(ctx.env.DB, {
+          conversation_id: ctx.params.id,
+          role: body.role as "user" | "assistant" | "system" | "tool",
+          content: body.content,
+          metadata: body.metadata,
+        });
+
+        if (body.role === "user" || body.role === "assistant") {
+          const conv = await getConversation(ctx.env.DB, ctx.params.id);
+          if (conv) {
+            await upsertMessageVector(ctx.env, {
+              message_id: msgId,
+              conversation_id: ctx.params.id,
+              namespace_id: conv.namespace_id,
+              content: body.content,
+              role: body.role,
+            });
+          }
+        }
+        return json({ id: msgId, role: body.role }, 201);
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Add message",
+      description: "Add a message and embed user/assistant messages for search.",
+      tags: ["Conversations"],
+      operationId: "addMessage",
+      parameters: [idPathParam("Conversation ID")],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["role", "content"],
+              properties: {
+                role: roleEnum(),
+                content: { type: "string", maxLength: 50000 },
+                metadata: metadataSchema(),
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "201": {
+          description: "Message added",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: { id: { type: "string" }, role: { type: "string" } },
+              },
+            },
+          },
+        },
+      },
+    },
+  );
+
+  defineRoute(
+    "GET",
+    "/api/v1/namespaces/:namespace_id/messages",
+    async (ctx) => {
+      try {
+        await assertNamespaceAccess(ctx.env.DB, ctx.params.namespace_id, ctx.email);
+        const query = ctx.query.get("q");
+        if (!query) return jsonError("q parameter is required", 400);
+        const limit = queryLimit(ctx.query, 100, 50);
+        const rows = await searchMessages(ctx.env.DB, ctx.params.namespace_id, query, { limit });
+        return json(rows);
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Search messages",
+      description: "Keyword search across all messages in a namespace.",
+      tags: ["Conversations"],
+      operationId: "searchMessages",
+      parameters: [
+        nsPathParam(),
+        {
+          name: "q",
+          in: "query",
+          required: true,
+          description: "Search query",
+          schema: { type: "string" },
+        },
+        limitQueryParam(100),
+      ],
+      responses: {
+        "200": {
+          description: "Array of messages",
+          content: {
+            "application/json": { schema: { type: "array", items: messageSchema() } },
+          },
+        },
+      },
+    },
+  );
+}

--- a/src/api/routes/namespaces.ts
+++ b/src/api/routes/namespaces.ts
@@ -1,0 +1,89 @@
+/** Namespace REST endpoints + OpenAPI definitions. */
+import { defineRoute } from "../registry.js";
+import { json, jsonError, parseBody, handleError } from "../middleware.js";
+import { createNamespace, listNamespaces } from "../../graph/index.js";
+import { namespaceSchema } from "../schemas.js";
+
+export function registerNamespaceRoutes(): void {
+  defineRoute(
+    "GET",
+    "/api/v1/namespaces",
+    async (ctx) => {
+      try {
+        const rows = await listNamespaces(ctx.env.DB, ctx.email);
+        return json(rows);
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "List namespaces",
+      description: "List all namespaces owned by the authenticated user.",
+      tags: ["Namespaces"],
+      operationId: "listNamespaces",
+      responses: {
+        "200": {
+          description: "Array of namespaces",
+          content: {
+            "application/json": { schema: { type: "array", items: namespaceSchema() } },
+          },
+        },
+      },
+    },
+  );
+
+  defineRoute(
+    "POST",
+    "/api/v1/namespaces",
+    async (ctx, request) => {
+      try {
+        const body = await parseBody<{ name?: string; description?: string }>(request);
+        if (body instanceof Response) return body;
+        if (!body.name) return jsonError("name is required", 400);
+
+        const id = await createNamespace(ctx.env.DB, {
+          name: body.name,
+          description: body.description,
+          owner: ctx.email,
+        });
+        return json({ id, name: body.name }, 201);
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Create namespace",
+      description: "Create a new memory namespace.",
+      tags: ["Namespaces"],
+      operationId: "createNamespace",
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["name"],
+              properties: {
+                name: { type: "string", maxLength: 200 },
+                description: { type: "string", maxLength: 2000 },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "201": {
+          description: "Namespace created",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: { id: { type: "string" }, name: { type: "string" } },
+              },
+            },
+          },
+        },
+      },
+    },
+  );
+}

--- a/src/api/routes/relations.ts
+++ b/src/api/routes/relations.ts
@@ -1,0 +1,189 @@
+/** Relation REST endpoints + OpenAPI definitions. */
+import { defineRoute } from "../registry.js";
+import { json, jsonError, parseBody, handleError } from "../middleware.js";
+import {
+  createRelation,
+  getRelationsFrom,
+  getRelationsTo,
+  deleteRelation,
+} from "../../graph/index.js";
+import { assertNamespaceAccess, assertEntityAccess, assertRelationAccess } from "../../auth.js";
+import {
+  nsPathParam,
+  idPathParam,
+  limitQueryParam,
+  queryLimit,
+  relationSchema,
+  okSchema,
+  metadataSchema,
+} from "../schemas.js";
+
+export function registerRelationRoutes(): void {
+  defineRoute(
+    "POST",
+    "/api/v1/namespaces/:namespace_id/relations",
+    async (ctx, request) => {
+      try {
+        await assertNamespaceAccess(ctx.env.DB, ctx.params.namespace_id, ctx.email);
+        const body = await parseBody<{
+          source_id?: string;
+          target_id?: string;
+          relation_type?: string;
+          weight?: number;
+          metadata?: Record<string, unknown>;
+        }>(request);
+        if (body instanceof Response) return body;
+        if (!body.source_id || !body.target_id || !body.relation_type) {
+          return jsonError("source_id, target_id, and relation_type are required", 400);
+        }
+
+        await assertEntityAccess(ctx.env.DB, body.source_id, ctx.email);
+        await assertEntityAccess(ctx.env.DB, body.target_id, ctx.email);
+
+        const id = await createRelation(ctx.env.DB, {
+          namespace_id: ctx.params.namespace_id,
+          source_id: body.source_id,
+          target_id: body.target_id,
+          relation_type: body.relation_type,
+          weight: body.weight,
+          metadata: body.metadata,
+        });
+        return json(
+          {
+            id,
+            source_id: body.source_id,
+            target_id: body.target_id,
+            relation_type: body.relation_type,
+          },
+          201,
+        );
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Create relation",
+      description: "Create a directed relation between two entities in the same namespace.",
+      tags: ["Relations"],
+      operationId: "createRelation",
+      parameters: [nsPathParam()],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["source_id", "target_id", "relation_type"],
+              properties: {
+                source_id: { type: "string", description: "Source entity ID" },
+                target_id: { type: "string", description: "Target entity ID" },
+                relation_type: {
+                  type: "string",
+                  maxLength: 200,
+                  description: "e.g. knows, uses, depends_on",
+                },
+                weight: { type: "number", minimum: 0, maximum: 1 },
+                metadata: metadataSchema(),
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "201": {
+          description: "Relation created",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  id: { type: "string" },
+                  source_id: { type: "string" },
+                  target_id: { type: "string" },
+                  relation_type: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  );
+
+  defineRoute(
+    "GET",
+    "/api/v1/entities/:id/relations",
+    async (ctx) => {
+      try {
+        await assertEntityAccess(ctx.env.DB, ctx.params.id, ctx.email);
+        const direction = ctx.query.get("direction") ?? "both";
+        const relationType = ctx.query.get("relation_type") ?? undefined;
+        const limit = queryLimit(ctx.query, 50);
+        const opts = { relation_type: relationType, limit };
+
+        const results: unknown[] = [];
+        if (direction === "from" || direction === "both") {
+          results.push(...(await getRelationsFrom(ctx.env.DB, ctx.params.id, opts)));
+        }
+        if (direction === "to" || direction === "both") {
+          results.push(...(await getRelationsTo(ctx.env.DB, ctx.params.id, opts)));
+        }
+        return json(results);
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Get relations",
+      description: "Query relations from/to an entity.",
+      tags: ["Relations"],
+      operationId: "getRelations",
+      parameters: [
+        idPathParam("Entity ID"),
+        {
+          name: "direction",
+          in: "query",
+          schema: { type: "string", enum: ["from", "to", "both"], default: "both" },
+        },
+        { name: "relation_type", in: "query", schema: { type: "string" } },
+        limitQueryParam(50),
+      ],
+      responses: {
+        "200": {
+          description: "Array of relations",
+          content: {
+            "application/json": { schema: { type: "array", items: relationSchema() } },
+          },
+        },
+      },
+    },
+  );
+
+  defineRoute(
+    "DELETE",
+    "/api/v1/relations/:id",
+    async (ctx) => {
+      try {
+        await assertRelationAccess(ctx.env.DB, ctx.params.id, ctx.email);
+        await deleteRelation(ctx.env.DB, ctx.params.id);
+        return json({ ok: true });
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Delete relation",
+      tags: ["Relations"],
+      operationId: "deleteRelation",
+      parameters: [idPathParam("Relation ID")],
+      responses: {
+        "200": {
+          description: "Deleted",
+          content: {
+            "application/json": { schema: okSchema() },
+          },
+        },
+      },
+    },
+  );
+}

--- a/src/api/routes/search.ts
+++ b/src/api/routes/search.ts
@@ -1,0 +1,137 @@
+/** Semantic search REST endpoint + OpenAPI definition. */
+import { defineRoute } from "../registry.js";
+import { json, jsonError, handleError } from "../middleware.js";
+import { assertNamespaceAccess } from "../../auth.js";
+import { semanticSearch } from "../../embeddings.js";
+import { getEntity, getRelationsFrom, getRelationsTo } from "../../graph/index.js";
+import { recallMemories, getMemoriesForEntity } from "../../memories.js";
+
+export function registerSearchRoutes(): void {
+  defineRoute(
+    "POST",
+    "/api/v1/namespaces/:namespace_id/search",
+    async (ctx, request) => {
+      try {
+        await assertNamespaceAccess(ctx.env.DB, ctx.params.namespace_id, ctx.email);
+        const body = (await request.json()) as {
+          query?: string;
+          mode?: string;
+          kind?: string;
+          limit?: number;
+        };
+        if (!body.query) return jsonError("query is required", 400);
+
+        const mode = body.mode ?? "semantic";
+        const limit = Math.min(body.limit ?? (mode === "context" ? 5 : 10), 20);
+        const kind = body.kind as "entity" | "memory" | "message" | undefined;
+
+        const matches = await semanticSearch(ctx.env, body.query, ctx.params.namespace_id, {
+          kind,
+          limit,
+        });
+
+        if (mode === "semantic") {
+          return json({ matches });
+        }
+
+        // Context mode: enrich entity matches with graph + memories
+        const entities: unknown[] = [];
+        const entityIds = matches
+          .filter((m) => m.kind === "entity")
+          .map((m) => m.metadata.entity_id)
+          .filter(Boolean);
+
+        for (const eid of entityIds) {
+          const entity = await getEntity(ctx.env.DB, eid);
+          if (!entity) continue;
+          const [from, to, memories] = await Promise.all([
+            getRelationsFrom(ctx.env.DB, eid, { limit: 5 }),
+            getRelationsTo(ctx.env.DB, eid, { limit: 5 }),
+            getMemoriesForEntity(ctx.env.DB, eid, { limit: 5 }),
+          ]);
+          entities.push({ entity, relations: [...from, ...to], memories });
+        }
+
+        const topMemories = await recallMemories(ctx.env.DB, ctx.params.namespace_id, {
+          limit: Math.max(1, limit - entityIds.length),
+        });
+
+        return json({ matches, entities, top_memories: topMemories });
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Semantic search",
+      description:
+        "Vector search across entities, memories, and messages. " +
+        "Use mode=context to enrich results with graph relations and ranked memories.",
+      tags: ["Search"],
+      operationId: "semanticSearch",
+      parameters: [
+        { name: "namespace_id", in: "path", required: true, schema: { type: "string" } },
+      ],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["query"],
+              properties: {
+                query: { type: "string", maxLength: 1000 },
+                mode: { type: "string", enum: ["semantic", "context"], default: "semantic" },
+                kind: {
+                  type: "string",
+                  enum: ["entity", "memory", "message"],
+                  description: "Filter by type",
+                },
+                limit: {
+                  type: "integer",
+                  maximum: 20,
+                  description: "Default 10 (semantic) or 5 (context)",
+                },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "200": {
+          description: "Search results",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  matches: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        id: { type: "string" },
+                        kind: { type: "string" },
+                        score: { type: "number" },
+                        metadata: { type: "object" },
+                      },
+                    },
+                  },
+                  entities: {
+                    type: "array",
+                    items: { type: "object" },
+                    description: "Context mode only",
+                  },
+                  top_memories: {
+                    type: "array",
+                    items: { type: "object" },
+                    description: "Context mode only",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  );
+}

--- a/src/api/routes/token-crud.ts
+++ b/src/api/routes/token-crud.ts
@@ -1,0 +1,142 @@
+/**
+ * Single service-token operations: get, update (label), and revoke.
+ *
+ * Collection-level endpoints (bind, list) live in tokens.ts.
+ */
+import { defineRoute } from "../registry.js";
+import { json, jsonError, parseBody, handleError } from "../middleware.js";
+import { ST_PREFIX } from "../service-tokens.js";
+import type { ServiceTokenMapping } from "../service-tokens.js";
+import { tokenSchema } from "../schemas.js";
+
+const cnParam = {
+  name: "common_name",
+  in: "path" as const,
+  required: true,
+  description: "CF-Access-Client-Id",
+  schema: { type: "string" as const },
+};
+
+export function registerTokenCrudRoutes(): void {
+  // --- GET /api/v1/admin/service-tokens/:common_name ---
+
+  defineRoute(
+    "GET",
+    "/api/v1/admin/service-tokens/:common_name",
+    async (ctx) => {
+      try {
+        const key = `${ST_PREFIX}${ctx.params.common_name}`;
+        const mapping = await ctx.env.CACHE.get<ServiceTokenMapping>(key, "json");
+        if (!mapping) return jsonError("Service token not found", 404);
+        if (mapping.email !== ctx.email) return jsonError("Access denied", 403);
+        return json({ common_name: ctx.params.common_name, ...mapping });
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Get service token binding",
+      tags: ["Admin"],
+      operationId: "getServiceToken",
+      parameters: [cnParam],
+      responses: {
+        "200": {
+          description: "Service token binding",
+          content: { "application/json": { schema: tokenSchema() } },
+        },
+      },
+    },
+  );
+
+  // --- PATCH /api/v1/admin/service-tokens/:common_name ---
+
+  defineRoute(
+    "PATCH",
+    "/api/v1/admin/service-tokens/:common_name",
+    async (ctx, request) => {
+      try {
+        const key = `${ST_PREFIX}${ctx.params.common_name}`;
+        const mapping = await ctx.env.CACHE.get<ServiceTokenMapping>(key, "json");
+        if (!mapping) return jsonError("Service token not found", 404);
+        if (mapping.email !== ctx.email) return jsonError("Access denied", 403);
+
+        const body = await parseBody<{ label?: string }>(request);
+        if (body instanceof Response) return body;
+        if (!body.label) return jsonError("label is required", 400);
+
+        mapping.label = body.label;
+        await ctx.env.CACHE.put(key, JSON.stringify(mapping));
+        return json({ common_name: ctx.params.common_name, ...mapping });
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Update service token binding",
+      description: "Update the label on a service token binding.",
+      tags: ["Admin"],
+      operationId: "updateServiceToken",
+      parameters: [cnParam],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["label"],
+              properties: {
+                label: { type: "string", description: "New human-readable label" },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "200": {
+          description: "Updated service token binding",
+          content: { "application/json": { schema: tokenSchema() } },
+        },
+      },
+    },
+  );
+
+  // --- DELETE /api/v1/admin/service-tokens/:common_name ---
+
+  defineRoute(
+    "DELETE",
+    "/api/v1/admin/service-tokens/:common_name",
+    async (ctx) => {
+      try {
+        const key = `${ST_PREFIX}${ctx.params.common_name}`;
+        const mapping = await ctx.env.CACHE.get<ServiceTokenMapping>(key, "json");
+        if (!mapping) return jsonError("Service token not found", 404);
+        if (mapping.email !== ctx.email) return jsonError("Access denied", 403);
+        await ctx.env.CACHE.delete(key);
+        return json({ ok: true });
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Revoke service token binding",
+      description:
+        "Remove the email binding for a service token. The token can no longer access the API.",
+      tags: ["Admin"],
+      operationId: "revokeServiceToken",
+      parameters: [cnParam],
+      responses: {
+        "200": {
+          description: "Revoked",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: { ok: { type: "boolean" } },
+              },
+            },
+          },
+        },
+      },
+    },
+  );
+}

--- a/src/api/routes/tokens.ts
+++ b/src/api/routes/tokens.ts
@@ -1,0 +1,127 @@
+/**
+ * Service token collection endpoints: bind (POST) and list (GET).
+ *
+ * Bindings are stored in KV as: key "st:<common_name>" → {email, label, created_at}.
+ * The common_name equals the CF-Access-Client-Id and survives token rotation.
+ *
+ * Single-token operations (get, update, delete) live in token-crud.ts.
+ */
+import { defineRoute } from "../registry.js";
+import { json, jsonError, parseBody, handleError } from "../middleware.js";
+import { ST_PREFIX } from "../service-tokens.js";
+import type { ServiceTokenMapping } from "../service-tokens.js";
+import { tokenSchema } from "../schemas.js";
+
+export function registerTokenRoutes(): void {
+  // --- POST /api/v1/admin/service-tokens (bind) ---
+
+  defineRoute(
+    "POST",
+    "/api/v1/admin/service-tokens",
+    async (ctx, request) => {
+      try {
+        const body = await parseBody<{ common_name?: string; label?: string }>(request);
+        if (body instanceof Response) return body;
+        if (!body.common_name) return jsonError("common_name is required", 400);
+
+        const key = `${ST_PREFIX}${body.common_name}`;
+        const existing = await ctx.env.CACHE.get<ServiceTokenMapping>(key, "json");
+        if (existing) {
+          return jsonError(`Service token already bound to ${existing.email}`, 409);
+        }
+
+        const mapping: ServiceTokenMapping = {
+          email: ctx.email,
+          label: body.label ?? body.common_name,
+          created_at: Math.floor(Date.now() / 1000),
+        };
+        await ctx.env.CACHE.put(key, JSON.stringify(mapping));
+        return json({ common_name: body.common_name, ...mapping }, 201);
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Bind service token",
+      description:
+        "Bind a Cloudflare Access service token to the authenticated user's email. " +
+        "The common_name is the CF-Access-Client-Id shown when you create the service token.",
+      tags: ["Admin"],
+      operationId: "bindServiceToken",
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["common_name"],
+              properties: {
+                common_name: {
+                  type: "string",
+                  description: "CF-Access-Client-Id (e.g. abc123.access)",
+                },
+                label: { type: "string", description: "Human-readable label" },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "201": {
+          description: "Service token bound",
+          content: { "application/json": { schema: tokenSchema() } },
+        },
+        "409": {
+          description: "Service token already bound",
+          content: {
+            "application/json": {
+              schema: { type: "object", properties: { error: { type: "string" } } },
+            },
+          },
+        },
+      },
+    },
+  );
+
+  // --- GET /api/v1/admin/service-tokens (list) ---
+
+  defineRoute(
+    "GET",
+    "/api/v1/admin/service-tokens",
+    async (ctx) => {
+      try {
+        const tokens: Array<{ common_name: string } & ServiceTokenMapping> = [];
+        let cursor: string | undefined;
+        do {
+          const batch = await ctx.env.CACHE.list({ prefix: ST_PREFIX, cursor });
+          for (const key of batch.keys) {
+            const mapping = await ctx.env.CACHE.get<ServiceTokenMapping>(key.name, "json");
+            if (mapping && mapping.email === ctx.email) {
+              tokens.push({ common_name: key.name.slice(ST_PREFIX.length), ...mapping });
+            }
+          }
+          cursor = batch.list_complete ? undefined : (batch.cursor as string);
+        } while (cursor);
+        return json(tokens);
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "List service token bindings",
+      description: "List all service tokens bound to the authenticated user's email.",
+      tags: ["Admin"],
+      operationId: "listServiceTokens",
+      responses: {
+        "200": {
+          description: "List of bound service tokens",
+          content: {
+            "application/json": {
+              schema: { type: "array", items: tokenSchema() },
+            },
+          },
+        },
+      },
+    },
+  );
+}

--- a/src/api/routes/traversal.ts
+++ b/src/api/routes/traversal.ts
@@ -1,0 +1,72 @@
+/** Graph traversal REST endpoint + OpenAPI definition. */
+import { defineRoute } from "../registry.js";
+import { json, handleError } from "../middleware.js";
+import { traverse } from "../../graph/index.js";
+import { assertEntityAccess } from "../../auth.js";
+
+export function registerTraversalRoutes(): void {
+  defineRoute(
+    "GET",
+    "/api/v1/entities/:id/traverse",
+    async (ctx) => {
+      try {
+        await assertEntityAccess(ctx.env.DB, ctx.params.id, ctx.email);
+        const maxDepth = Math.min(Number(ctx.query.get("max_depth") ?? 2), 5);
+        const typesParam = ctx.query.get("relation_types");
+        const relationTypes = typesParam ? typesParam.split(",") : undefined;
+
+        const result = await traverse(ctx.env.DB, ctx.params.id, {
+          maxDepth,
+          relationTypes,
+        });
+        return json(result);
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Traverse graph",
+      description:
+        "BFS from an entity up to max_depth hops. Returns reachable entities and relations.",
+      tags: ["Traversal"],
+      operationId: "traverseGraph",
+      parameters: [
+        {
+          name: "id",
+          in: "path",
+          required: true,
+          description: "Start entity ID",
+          schema: { type: "string" },
+        },
+        {
+          name: "max_depth",
+          in: "query",
+          description: "Max hops (default 2, max 5)",
+          schema: { type: "integer", maximum: 5, default: 2 },
+        },
+        {
+          name: "relation_types",
+          in: "query",
+          description: "Comma-separated relation types to follow",
+          schema: { type: "string" },
+        },
+      ],
+      responses: {
+        "200": {
+          description: "Traversal result",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  entities: { type: "array", items: { type: "object" } },
+                  relations: { type: "array", items: { type: "object" } },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  );
+}

--- a/src/api/row-parsers.ts
+++ b/src/api/row-parsers.ts
@@ -1,0 +1,13 @@
+/** Shared row-parsing helpers for converting DB rows to API responses. */
+import { parseJson } from "../utils.js";
+import type { EntityRow, MemoryRow } from "../types.js";
+
+/** Parse metadata JSON string in an entity row into an object. */
+export function parseEntityRow(row: EntityRow) {
+  return { ...row, metadata: row.metadata ? parseJson(row.metadata) : null };
+}
+
+/** Parse metadata JSON string in a memory row into an object. */
+export function parseMemoryRow(row: MemoryRow) {
+  return { ...row, metadata: row.metadata ? parseJson(row.metadata) : null };
+}

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -1,0 +1,165 @@
+/** Reusable OpenAPI schema fragments, parameter helpers, and query utilities. */
+import type { SchemaObject, ParameterObject } from "./types.js";
+
+// --- Query helpers ---
+
+/** Parse a "limit" query parameter with a default and maximum cap. */
+export function queryLimit(query: URLSearchParams, max: number, def: number = 20): number {
+  return Math.min(Number(query.get("limit") ?? def), max);
+}
+
+// --- Common parameters ---
+
+export function nsPathParam(): ParameterObject {
+  return { name: "namespace_id", in: "path", required: true, schema: { type: "string" } };
+}
+
+export function idPathParam(desc: string): ParameterObject {
+  return { name: "id", in: "path", required: true, description: desc, schema: { type: "string" } };
+}
+
+export function limitQueryParam(max: number): ParameterObject {
+  return { name: "limit", in: "query", schema: { type: "integer", maximum: max } };
+}
+
+// --- Common response schemas ---
+
+export function okSchema(): SchemaObject {
+  return { type: "object", properties: { ok: { type: "boolean" } } };
+}
+
+export function errorBodySchema(): SchemaObject {
+  return { type: "object", properties: { error: { type: "string" } }, required: ["error"] };
+}
+
+// --- Domain schemas ---
+
+export function namespaceSchema(): SchemaObject {
+  return {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      name: { type: "string" },
+      description: { type: "string", nullable: true },
+      owner: { type: "string", nullable: true },
+      metadata: { type: "string", nullable: true },
+      created_at: { type: "number" },
+      updated_at: { type: "number" },
+    },
+  };
+}
+
+export function entitySchema(): SchemaObject {
+  return {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      namespace_id: { type: "string" },
+      name: { type: "string" },
+      type: { type: "string" },
+      summary: { type: "string", nullable: true },
+      metadata: { type: "object", nullable: true },
+      created_at: { type: "number" },
+      updated_at: { type: "number" },
+      last_accessed_at: { type: "number" },
+      access_count: { type: "number" },
+    },
+  };
+}
+
+export function relationSchema(): SchemaObject {
+  return {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      namespace_id: { type: "string" },
+      source_id: { type: "string" },
+      target_id: { type: "string" },
+      relation_type: { type: "string" },
+      weight: { type: "number" },
+      metadata: { type: "string", nullable: true },
+      created_at: { type: "number" },
+      updated_at: { type: "number" },
+    },
+  };
+}
+
+export function memorySchema(): SchemaObject {
+  return {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      namespace_id: { type: "string" },
+      content: { type: "string" },
+      type: { type: "string" },
+      source: { type: "string", nullable: true },
+      importance: { type: "number" },
+      metadata: { type: "object", nullable: true },
+      created_at: { type: "number" },
+      updated_at: { type: "number" },
+      last_accessed_at: { type: "number" },
+      access_count: { type: "number" },
+    },
+  };
+}
+
+export function conversationSchema(): SchemaObject {
+  return {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      namespace_id: { type: "string" },
+      title: { type: "string", nullable: true },
+      metadata: { type: "string", nullable: true },
+      created_at: { type: "number" },
+      updated_at: { type: "number" },
+    },
+  };
+}
+
+export function messageSchema(): SchemaObject {
+  return {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      conversation_id: { type: "string" },
+      role: { type: "string" },
+      content: { type: "string" },
+      metadata: { type: "string", nullable: true },
+      created_at: { type: "number" },
+    },
+  };
+}
+
+export function tokenSchema(): SchemaObject {
+  return {
+    type: "object",
+    properties: {
+      common_name: { type: "string" },
+      email: { type: "string" },
+      label: { type: "string" },
+      created_at: { type: "number" },
+    },
+  };
+}
+
+// --- Reusable input fragments ---
+
+/** Metadata input schema for request bodies. */
+export function metadataSchema(): SchemaObject {
+  return { type: "object", additionalProperties: true, description: "Arbitrary JSON metadata" };
+}
+
+/** Memory type enum values. */
+export const MEMORY_TYPES = ["fact", "observation", "preference", "instruction"] as const;
+
+export function memoryTypeEnum(): SchemaObject {
+  return { type: "string", enum: [...MEMORY_TYPES] };
+}
+
+/** Message role enum values. */
+export const MESSAGE_ROLES = ["user", "assistant", "system", "tool"] as const;
+
+export function roleEnum(): SchemaObject {
+  return { type: "string", enum: [...MESSAGE_ROLES] };
+}

--- a/src/api/service-tokens.ts
+++ b/src/api/service-tokens.ts
@@ -1,0 +1,11 @@
+/** Service token types and constants shared across middleware and route files. */
+
+/** KV key prefix for service token → email mappings. */
+export const ST_PREFIX = "st:";
+
+/** Shape of a service token mapping stored in KV. */
+export interface ServiceTokenMapping {
+  email: string;
+  label: string;
+  created_at: number;
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,0 +1,71 @@
+/** Shared types for the REST API layer. */
+import type { Env } from "../types.js";
+
+/** Authenticated request context passed to every route handler. */
+export interface ApiContext {
+  env: Env;
+  email: string;
+  params: Record<string, string>;
+  query: URLSearchParams;
+}
+
+/** HTTP methods supported by the router. */
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+/** A single API route definition. */
+export interface RouteDefinition {
+  method: HttpMethod;
+  pattern: string; // e.g. "/api/v1/entities/:id"
+  handler: (ctx: ApiContext, request: Request) => Promise<Response>;
+  spec: PathOperation;
+  /** If true, skip auth (e.g. docs, openapi.json). */
+  public?: boolean;
+}
+
+// --- OpenAPI 3.1 subset types (just enough to build accurate specs) ---
+
+export interface PathOperation {
+  summary: string;
+  description?: string;
+  tags: string[];
+  operationId: string;
+  parameters?: ParameterObject[];
+  requestBody?: RequestBodyObject;
+  responses: Record<string, ResponseObject>;
+}
+
+export interface ParameterObject {
+  name: string;
+  in: "path" | "query" | "header";
+  required?: boolean;
+  description?: string;
+  schema: SchemaObject;
+}
+
+export interface RequestBodyObject {
+  required?: boolean;
+  content: Record<string, { schema: SchemaObject }>;
+}
+
+export interface ResponseObject {
+  description: string;
+  content?: Record<string, { schema: SchemaObject }>;
+}
+
+/** JSON Schema subset for OpenAPI 3.1. */
+export interface SchemaObject {
+  type?: string;
+  format?: string;
+  description?: string;
+  properties?: Record<string, SchemaObject>;
+  required?: string[];
+  items?: SchemaObject;
+  enum?: (string | number)[];
+  nullable?: boolean;
+  maxLength?: number;
+  maximum?: number;
+  minimum?: number;
+  default?: unknown;
+  example?: unknown;
+  additionalProperties?: boolean | SchemaObject;
+}

--- a/src/reindex.ts
+++ b/src/reindex.ts
@@ -1,0 +1,77 @@
+/** Shared batch-reindex logic for entities and memories into Vectorize. */
+import type { Env } from "./types.js";
+import { embedBatch } from "./embeddings.js";
+
+/** Items per Workers AI + Vectorize batch. Keeps each call well within limits. */
+export const REINDEX_BATCH_SIZE = 25;
+
+export interface ReindexEntityItem {
+  id: string;
+  namespace_id: string;
+  name: string;
+  type: string;
+  summary: string | null;
+}
+
+export interface ReindexMemoryItem {
+  id: string;
+  namespace_id: string;
+  content: string;
+  type: string;
+}
+
+export interface ReindexResult {
+  entities: number;
+  memories: number;
+  errors: number;
+}
+
+/** Split an array into chunks of the given size. */
+export function chunks<T>(arr: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    result.push(arr.slice(i, i + size));
+  }
+  return result;
+}
+
+/** Batch-embed and upsert a chunk of entities into Vectorize. Returns count embedded. */
+export async function reindexEntityChunk(env: Env, chunk: ReindexEntityItem[]): Promise<number> {
+  const texts = chunk.map((e) => [e.name, e.type, e.summary].filter(Boolean).join(" | "));
+  const vectors = await embedBatch(env.AI, texts);
+
+  const entries: VectorizeVector[] = chunk.map((e, i) => ({
+    id: `entity:${e.id}`,
+    values: vectors[i],
+    metadata: {
+      kind: "entity",
+      entity_id: e.id,
+      namespace_id: e.namespace_id,
+      name: e.name,
+      type: e.type,
+    },
+  }));
+
+  await env.VECTORIZE.upsert(entries);
+  return chunk.length;
+}
+
+/** Batch-embed and upsert a chunk of memories into Vectorize. Returns count embedded. */
+export async function reindexMemoryChunk(env: Env, chunk: ReindexMemoryItem[]): Promise<number> {
+  const texts = chunk.map((m) => m.content);
+  const vectors = await embedBatch(env.AI, texts);
+
+  const entries: VectorizeVector[] = chunk.map((m, i) => ({
+    id: `memory:${m.id}`,
+    values: vectors[i],
+    metadata: {
+      kind: "memory",
+      memory_id: m.id,
+      namespace_id: m.namespace_id,
+      type: m.type,
+    },
+  }));
+
+  await env.VECTORIZE.upsert(entries);
+  return chunk.length;
+}

--- a/src/tools/admin.ts
+++ b/src/tools/admin.ts
@@ -2,84 +2,11 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { Env } from "../types.js";
-import { embedBatch } from "../embeddings.js";
 import { assertNamespaceAccess } from "../auth.js";
 import { claimUnownedNamespaces } from "../graph/namespaces.js";
 import { txt, ok } from "../response-helpers.js";
-
-/** Items per Workers AI + Vectorize batch. Keeps each call well within limits. */
-const BATCH_SIZE = 25;
-
-interface EntityItem {
-  id: string;
-  namespace_id: string;
-  name: string;
-  type: string;
-  summary: string | null;
-}
-
-interface MemoryItem {
-  id: string;
-  namespace_id: string;
-  content: string;
-  type: string;
-}
-
-/**
- * Process a chunk of entities: batch-embed then batch-upsert into Vectorize.
- * Returns [successCount, errorCount].
- */
-async function reindexEntityChunk(env: Env, chunk: EntityItem[]): Promise<[number, number]> {
-  const texts = chunk.map((e) => [e.name, e.type, e.summary].filter(Boolean).join(" | "));
-  const vectors = await embedBatch(env.AI, texts);
-
-  const entries: VectorizeVector[] = chunk.map((e, i) => ({
-    id: `entity:${e.id}`,
-    values: vectors[i],
-    metadata: {
-      kind: "entity",
-      entity_id: e.id,
-      namespace_id: e.namespace_id,
-      name: e.name,
-      type: e.type,
-    },
-  }));
-
-  await env.VECTORIZE.upsert(entries);
-  return [chunk.length, 0];
-}
-
-/**
- * Process a chunk of memories: batch-embed then batch-upsert into Vectorize.
- * Returns [successCount, errorCount].
- */
-async function reindexMemoryChunk(env: Env, chunk: MemoryItem[]): Promise<[number, number]> {
-  const texts = chunk.map((m) => m.content);
-  const vectors = await embedBatch(env.AI, texts);
-
-  const entries: VectorizeVector[] = chunk.map((m, i) => ({
-    id: `memory:${m.id}`,
-    values: vectors[i],
-    metadata: {
-      kind: "memory",
-      memory_id: m.id,
-      namespace_id: m.namespace_id,
-      type: m.type,
-    },
-  }));
-
-  await env.VECTORIZE.upsert(entries);
-  return [chunk.length, 0];
-}
-
-/** Split an array into chunks of the given size. */
-function chunks<T>(arr: T[], size: number): T[][] {
-  const result: T[][] = [];
-  for (let i = 0; i < arr.length; i += size) {
-    result.push(arr.slice(i, i + size));
-  }
-  return result;
-}
+import { REINDEX_BATCH_SIZE, chunks, reindexEntityChunk, reindexMemoryChunk } from "../reindex.js";
+import type { ReindexEntityItem, ReindexMemoryItem } from "../reindex.js";
 
 export function registerAdminTools(server: McpServer, env: Env, email: string) {
   server.tool(
@@ -104,12 +31,11 @@ export function registerAdminTools(server: McpServer, env: Env, email: string) {
           : "SELECT id, namespace_id, name, type, summary FROM entities WHERE namespace_id = ?";
       const entityResult = await env.DB.prepare(entityQuery)
         .bind(namespace_id === "all" ? email : namespace_id)
-        .all<EntityItem>();
+        .all<ReindexEntityItem>();
 
-      for (const chunk of chunks(entityResult.results, BATCH_SIZE)) {
+      for (const chunk of chunks(entityResult.results, REINDEX_BATCH_SIZE)) {
         try {
-          const [ok] = await reindexEntityChunk(env, chunk);
-          entityCount += ok;
+          entityCount += await reindexEntityChunk(env, chunk);
         } catch {
           errorCount += chunk.length;
         }
@@ -122,12 +48,11 @@ export function registerAdminTools(server: McpServer, env: Env, email: string) {
           : "SELECT id, namespace_id, content, type FROM memories WHERE namespace_id = ?";
       const memoryResult = await env.DB.prepare(memoryQuery)
         .bind(namespace_id === "all" ? email : namespace_id)
-        .all<MemoryItem>();
+        .all<ReindexMemoryItem>();
 
-      for (const chunk of chunks(memoryResult.results, BATCH_SIZE)) {
+      for (const chunk of chunks(memoryResult.results, REINDEX_BATCH_SIZE)) {
         try {
-          const [ok] = await reindexMemoryChunk(env, chunk);
-          memoryCount += ok;
+          memoryCount += await reindexMemoryChunk(env, chunk);
         } catch {
           errorCount += chunk.length;
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,11 @@ export interface AuthProps {
   [key: string]: unknown;
 }
 
+// --- Shared enums ---
+
+export type MemoryType = "fact" | "observation" | "preference" | "instruction";
+export type MessageRole = "user" | "assistant" | "system" | "tool";
+
 // --- Domain types ---
 
 export interface Namespace {
@@ -77,7 +82,7 @@ export interface Conversation {
 export interface Message {
   id: string;
   conversation_id: string;
-  role: "user" | "assistant" | "system" | "tool";
+  role: MessageRole;
   content: string;
   metadata: Record<string, unknown> | null;
   created_at: number;
@@ -87,7 +92,7 @@ export interface Memory {
   id: string;
   namespace_id: string;
   content: string;
-  type: "fact" | "observation" | "preference" | "instruction";
+  type: MemoryType;
   source: string | null;
   importance: number;
   metadata: Record<string, unknown> | null;


### PR DESCRIPTION
## Summary

- Add full REST API at `/api/v1/*` — same data layer as MCP, accessible via HTTP
- Service token authentication via Cloudflare Access (JWT with `common_name` → KV email lookup)
- Auto-generated OpenAPI 3.1 spec at `/api/openapi.json` + Scalar docs at `/api/docs`

## What's new

**REST API (22 new files in `src/api/`):**
- Complete CRUD for namespaces, entities, relations, memories, conversations, messages
- Semantic search endpoint with context enrichment mode
- Admin endpoints: reindex vectors, claim namespaces
- Service token management: bind, list, get, update label, revoke

**Auth:**
- JWT verification from `Cf-Access-Jwt-Assertion` header with `CF_Authorization` cookie fallback
- Service token identity resolution: `common_name` → KV lookup → bound email
- All data operations scoped to authenticated user's email

**Modularity refactoring:**
- Extracted shared modules: `reindex.ts`, `row-parsers.ts`, `service-tokens.ts`
- Centralized OpenAPI schema helpers: `metadataSchema()`, `memoryTypeEnum()`, `roleEnum()`, `queryLimit()`
- Exported `MemoryType` and `MessageRole` from `types.ts`, eliminated duplicates
- No file exceeds 250-line cap

**Docs:**
- README rewritten with step-by-step Access setup, both auth flows, token management table
- AGENTS.md updated with new file structure, JWT cookie fallback, AUD tag caveat
- `.dev.vars.example` annotated with where to find each value

## No breaking changes

Interactive MCP clients (Claude, Cursor, OpenCode) are unaffected — same `/mcp` endpoint, same OAuth flow.