### PR TITLE
fix(auth): support multiple JWKS URLs and AUD tags for SaaS app tokens

### DIFF
--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -35,21 +35,25 @@ async function fetchAccessPublicKey(env: Env, kid: string): Promise<CryptoKey> {
   if (!env.ACCESS_JWKS_URL) {
     throw new Error("ACCESS_JWKS_URL not configured");
   }
-  const resp = await fetch(env.ACCESS_JWKS_URL);
-  const keys = (await resp.json()) as {
-    keys: (JsonWebKey & { kid: string })[];
-  };
-  const jwk = keys.keys.filter((key) => key.kid === kid)[0];
-  if (!jwk) {
-    throw new Error(`No matching JWK found for kid: ${kid}`);
+  // ACCESS_JWKS_URL may be comma-separated (e.g. team-level + SaaS app JWKS).
+  const urls = env.ACCESS_JWKS_URL.split(",").map((s) => s.trim());
+  for (const url of urls) {
+    const resp = await fetch(url);
+    const keys = (await resp.json()) as {
+      keys: (JsonWebKey & { kid: string })[];
+    };
+    const jwk = keys.keys.find((key) => key.kid === kid);
+    if (jwk) {
+      return crypto.subtle.importKey(
+        "jwk",
+        jwk,
+        { hash: "SHA-256", name: "RSASSA-PKCS1-v1_5" },
+        false,
+        ["verify"],
+      );
+    }
   }
-  return crypto.subtle.importKey(
-    "jwk",
-    jwk,
-    { hash: "SHA-256", name: "RSASSA-PKCS1-v1_5" },
-    false,
-    ["verify"],
-  );
+  throw new Error(`No matching JWK found for kid: ${kid}`);
 }
 
 /** Verify a Cloudflare Access ID token and return its claims. */
@@ -74,10 +78,12 @@ export async function verifyToken(env: Env, token: string): Promise<Record<strin
     throw new Error("expired token");
   }
 
-  // Validate audience claim against the Access application's AUD tag.
+  // Validate audience claim against allowed Access application AUD tags.
+  // ACCESS_AUD_TAG may be a single tag or comma-separated list (e.g. self-hosted + SaaS app).
   if (env.ACCESS_AUD_TAG) {
-    const aud = Array.isArray(claims.aud) ? claims.aud : [claims.aud];
-    if (!aud.includes(env.ACCESS_AUD_TAG)) {
+    const allowedAuds = env.ACCESS_AUD_TAG.split(",").map((s) => s.trim());
+    const tokenAuds = Array.isArray(claims.aud) ? claims.aud : [claims.aud];
+    if (!tokenAuds.some((a: string) => allowedAuds.includes(a))) {
       throw new Error("invalid audience");
     }
   }


### PR DESCRIPTION
## Summary

- `fetchAccessPublicKey()` now accepts comma-separated `ACCESS_JWKS_URL` values and tries each JWKS endpoint until a matching `kid` is found
- `verifyToken()` now accepts comma-separated `ACCESS_AUD_TAG` values for audience validation
- Fixes MCP OAuth `/callback` crash (`No matching JWK found for kid`) when the SaaS app id_token is signed with an app-specific key not present in the team-level JWKS

## Context

Cloudflare Access SaaS apps sign their OIDC id_tokens with app-specific keys that live at a different JWKS endpoint than the team-level `/cdn-cgi/access/certs`. The self-hosted Access app (protecting `/api`) and the SaaS app (for MCP OAuth) have different audience tags and different signing keys. This fix allows both to be validated by a single `verifyToken()` function.

## Changes

- `src/jwt.ts` — `fetchAccessPublicKey()` iterates over comma-separated JWKS URLs; AUD validation checks against comma-separated allowed tags