### PR TITLE
docs: remove hardcoded emails from HOWTO admin example

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -117,16 +117,11 @@ Admin-only operations (reindex, claim namespaces) are gated by a KV allowlist.
 **KV key:** `admin:emails` in the `CACHE` namespace
 **Value:** comma-separated emails, e.g. `alice@example.com,bob@example.com`
 
-Set via dashboard or CLI:
+Set via dashboard or CLI (use the CACHE namespace ID from each wrangler config):
 
 ```sh
-# Account A
-npx wrangler kv key put "admin:emails" "tim@schenanigans.com,tschneider@cloudflare.com,tim@taslabs.net" \
-  --namespace-id <CACHE_KV_ID_A>
-
-# Account B
-npx wrangler kv key put "admin:emails" "tim@schenanigans.com,tschneider@cloudflare.com,tim@taslabs.net" \
-  --namespace-id <CACHE_KV_ID_B>
+npx wrangler kv key put "admin:emails" "alice@example.com,bob@example.com" \
+  --namespace-id <CACHE_KV_NAMESPACE_ID> --remote
 ```
 
 No redeploy needed — changes take effect immediately. If the key is missing, all admin operations are denied (fail-closed).


### PR DESCRIPTION
## Summary

- Replace hardcoded personal emails in HOWTO admin role section with generic `alice@example.com,bob@example.com` placeholder