### PR TITLE
refactor(errors): centralize error handling helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Code is organized into focused modules with a 250-line cap per file:
 - `src/memories.ts` — Memory CRUD + temporal-decay recall ranking
 - `src/conversations.ts` — Conversation and message history
 - `src/utils.ts` — `generateId`, `decayScore`, JSON helpers
-- `src/response-helpers.ts` — Shared MCP response helpers (`txt`, `ok`, `cap`)
+- `src/response-helpers.ts` — Shared MCP response helpers (`txt`, `ok`, `err`, `safeMeta`, `toolHandler`, `cap`, `trunc`)
 - `src/reindex.ts` — Shared batch-reindex logic (entity/memory chunk embedding + Vectorize upsert) used by both MCP tools and REST API
 - `src/tools/` — One file per tool domain (namespace, entity, relation, traversal, memory, conversation, search, admin). Each exports a `register*Tools(server, env, email)` function.
 - `src/graph/` — D1 operations split by domain (namespaces, entities, relations, traversal) with barrel re-export via `index.ts`.

--- a/src/api/middleware.ts
+++ b/src/api/middleware.ts
@@ -174,6 +174,9 @@ export function handleError(error: unknown): Response {
   if (error instanceof AccessDeniedError) {
     return jsonError(error.message, 403);
   }
+  if (error instanceof SyntaxError) {
+    return jsonError("Invalid JSON body", 400);
+  }
   // eslint-disable-next-line no-console
   console.error("API error:", error);
   return jsonError("Internal server error", 500);

--- a/src/api/routes/admin.ts
+++ b/src/api/routes/admin.ts
@@ -1,6 +1,6 @@
 /** Admin REST endpoints + OpenAPI definitions. */
 import { defineRoute } from "../registry.js";
-import { json, jsonError, handleError } from "../middleware.js";
+import { json, jsonError, parseBody, handleError } from "../middleware.js";
 import { assertNamespaceAccess, isAdmin } from "../../auth.js";
 import { listNamespaces, claimUnownedNamespaces, searchEntities } from "../../graph/index.js";
 import { searchMemories } from "../../memories.js";
@@ -19,7 +19,8 @@ export function registerAdminRoutes(): void {
       try {
         if (!(await isAdmin(ctx.env.CACHE, ctx.email)))
           return jsonError("Admin access required", 403);
-        const body = (await request.json()) as { namespace_id?: string };
+        const body = await parseBody<{ namespace_id?: string }>(request);
+        if (body instanceof Response) return body;
         if (!body.namespace_id) return jsonError("namespace_id is required", 400);
 
         let namespaceIds: string[];

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared error classification used by both MCP tool handlers and REST API middleware.
+ *
+ * Centralizes the mapping from thrown errors to user-facing error info,
+ * so both protocols apply the same logic.
+ */
+
+import { AccessDeniedError } from "./auth.js";
+
+export type ErrorKind = "access_denied" | "bad_input" | "internal";
+
+export interface ClassifiedError {
+  kind: ErrorKind;
+  message: string;
+  /** HTTP status code (for API layer). */
+  status: number;
+  /** Whether to log the error server-side. */
+  log: boolean;
+}
+
+/** Classify an unknown thrown value into a structured error. */
+export function classifyError(error: unknown): ClassifiedError {
+  if (error instanceof AccessDeniedError) {
+    return { kind: "access_denied", message: error.message, status: 403, log: false };
+  }
+  if (error instanceof SyntaxError) {
+    return { kind: "bad_input", message: "Invalid JSON body", status: 400, log: false };
+  }
+  return { kind: "internal", message: "Internal error", status: 500, log: true };
+}

--- a/src/response-helpers.ts
+++ b/src/response-helpers.ts
@@ -1,11 +1,62 @@
 /** Shared response helpers for MCP tool handlers. */
 
-export function txt(data: unknown) {
+import { AccessDeniedError } from "./auth.js";
+
+/** Tool result type matching MCP SDK CallToolResult. */
+type ToolResult = {
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+};
+
+/** Success: return structured JSON data. */
+export function txt(data: unknown): ToolResult {
   return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
 }
 
-export function ok(msg: string) {
+/** Success: return a plain text message. */
+export function ok(msg: string): ToolResult {
   return { content: [{ type: "text" as const, text: msg }] };
+}
+
+/** Error: return a plain text message with isError: true. */
+export function err(msg: string): ToolResult {
+  return { content: [{ type: "text" as const, text: msg }], isError: true };
+}
+
+/** Safely parse a JSON metadata string. Returns err() result on bad input. */
+export function safeMeta(raw: string | undefined): Record<string, unknown> | ToolResult {
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return err("Invalid JSON in metadata field");
+  }
+}
+
+/** Check if safeMeta returned an error. */
+export function isMetaError(v: Record<string, unknown> | ToolResult): v is ToolResult {
+  return "isError" in v && v.isError === true;
+}
+
+/**
+ * Wrap a tool handler with centralized error handling.
+ * Catches AccessDeniedError → err(), unknown errors → err() with generic message.
+ */
+export function toolHandler<T>(
+  fn: (args: T) => Promise<ToolResult>,
+): (args: T) => Promise<ToolResult> {
+  return async (args: T) => {
+    try {
+      return await fn(args);
+    } catch (e) {
+      if (e instanceof AccessDeniedError) {
+        return err(e.message);
+      }
+      // eslint-disable-next-line no-console
+      console.error("Tool error:", e);
+      return err("Internal error — please try again");
+    }
+  };
 }
 
 export function cap(n: number | undefined, max: number, def: number) {
@@ -16,17 +67,4 @@ export function trunc(value: string | null | undefined, max = 400): string | nul
   if (typeof value !== "string") return value;
   if (value.length <= max) return value;
   return `${value.slice(0, max)}...`;
-}
-
-export function pickFields<T extends Record<string, unknown>>(
-  row: T,
-  fields: readonly string[],
-): Partial<T> {
-  const out: Partial<T> = {};
-  for (const field of fields) {
-    if (field in row) {
-      out[field as keyof T] = row[field] as T[keyof T];
-    }
-  }
-  return out;
 }

--- a/src/tools/admin.ts
+++ b/src/tools/admin.ts
@@ -4,13 +4,7 @@ import { z } from "zod";
 import type { Env } from "../types.js";
 import { assertNamespaceAccess, isAdmin } from "../auth.js";
 import { claimUnownedNamespaces } from "../graph/namespaces.js";
-import { txt, ok } from "../response-helpers.js";
-
-/** Guard: return error response if user is not an admin. */
-async function requireAdmin(env: Env, email: string) {
-  if (!(await isAdmin(env.CACHE, email))) return ok("Error: admin access required");
-  return null;
-}
+import { txt, err, ok, toolHandler } from "../response-helpers.js";
 import { REINDEX_BATCH_SIZE, chunks, reindexEntityChunk, reindexMemoryChunk } from "../reindex.js";
 import type { ReindexEntityItem, ReindexMemoryItem } from "../reindex.js";
 
@@ -28,9 +22,8 @@ export function registerAdminTools(server: McpServer, env: Env, email: string) {
       idempotentHint: true,
       openWorldHint: false,
     },
-    async ({ namespace_id }) => {
-      const denied = await requireAdmin(env, email);
-      if (denied) return denied;
+    toolHandler(async ({ namespace_id }) => {
+      if (!(await isAdmin(env.CACHE, email))) return err("admin access required");
       if (namespace_id !== "all") {
         await assertNamespaceAccess(env.DB, namespace_id, email);
       }
@@ -74,7 +67,7 @@ export function registerAdminTools(server: McpServer, env: Env, email: string) {
       }
 
       return txt({ entities: entityCount, memories: memoryCount, errors: errorCount });
-    },
+    }),
   );
 
   server.tool(
@@ -88,12 +81,11 @@ export function registerAdminTools(server: McpServer, env: Env, email: string) {
       idempotentHint: true,
       openWorldHint: false,
     },
-    async () => {
-      const denied = await requireAdmin(env, email);
-      if (denied) return denied;
+    toolHandler(async () => {
+      if (!(await isAdmin(env.CACHE, email))) return err("admin access required");
       const claimed = await claimUnownedNamespaces(env.DB, email);
       if (claimed === 0) return ok("No unowned namespaces found.");
       return txt({ claimed, owner: email });
-    },
+    }),
   );
 }

--- a/src/tools/conversation.ts
+++ b/src/tools/conversation.ts
@@ -6,7 +6,7 @@ import * as conversations from "../conversations.js";
 import * as vectorize from "../vectorize.js";
 import { assertNamespaceAccess, assertConversationAccess } from "../auth.js";
 import { toISO } from "../utils.js";
-import { txt, ok, cap, trunc } from "../response-helpers.js";
+import { txt, err, cap, trunc, safeMeta, isMetaError, toolHandler } from "../response-helpers.js";
 
 export function registerConversationTools(server: McpServer, env: Env, email: string) {
   server.tool(
@@ -27,13 +27,15 @@ export function registerConversationTools(server: McpServer, env: Env, email: st
       idempotentHint: true,
       openWorldHint: false,
     },
-    async ({ action, namespace_id, title, metadata, limit, compact }) => {
+    toolHandler(async ({ action, namespace_id, title, metadata, limit, compact }) => {
       await assertNamespaceAccess(env.DB, namespace_id, email);
       if (action === "create") {
+        const meta = safeMeta(metadata);
+        if (isMetaError(meta)) return meta;
         const id = await conversations.createConversation(env.DB, {
           namespace_id,
           title,
-          metadata: metadata ? JSON.parse(metadata) : undefined,
+          metadata: meta,
         });
         return txt({ id, title });
       }
@@ -54,7 +56,7 @@ export function registerConversationTools(server: McpServer, env: Env, email: st
               },
         ),
       );
-    },
+    }),
   );
 
   server.tool(
@@ -73,13 +75,15 @@ export function registerConversationTools(server: McpServer, env: Env, email: st
       idempotentHint: false,
       openWorldHint: false,
     },
-    async ({ conversation_id, role, content, metadata }) => {
+    toolHandler(async ({ conversation_id, role, content, metadata }) => {
       await assertConversationAccess(env.DB, conversation_id, email);
+      const meta = safeMeta(metadata);
+      if (isMetaError(meta)) return meta;
       const id = await conversations.addMessage(env.DB, {
         conversation_id,
         role,
         content,
-        metadata: metadata ? JSON.parse(metadata) : undefined,
+        metadata: meta,
       });
       if (role === "user" || role === "assistant") {
         const convo = await conversations.getConversation(env.DB, conversation_id);
@@ -93,7 +97,7 @@ export function registerConversationTools(server: McpServer, env: Env, email: st
           });
       }
       return txt({ id, role });
-    },
+    }),
   );
 
   server.tool(
@@ -125,7 +129,7 @@ export function registerConversationTools(server: McpServer, env: Env, email: st
       readOnlyHint: true,
       openWorldHint: false,
     },
-    async ({ conversation_id, namespace_id, query, limit, compact, verbose }) => {
+    toolHandler(async ({ conversation_id, namespace_id, query, limit, compact, verbose }) => {
       const n = cap(limit, 100, 50);
       const isCompact = compact ?? true;
       const full = verbose ?? false;
@@ -152,10 +156,10 @@ export function registerConversationTools(server: McpServer, env: Env, email: st
         const rows = await conversations.searchMessages(env.DB, namespace_id, query, { limit: n });
         return txt(rows.map(mapMsg));
       }
-      if (!conversation_id) return ok("Error: conversation_id or namespace_id+query required");
+      if (!conversation_id) return err("conversation_id or namespace_id+query required");
       await assertConversationAccess(env.DB, conversation_id, email);
       const rows = await conversations.getMessages(env.DB, conversation_id, { limit: n });
       return txt(rows.map(mapMsg));
-    },
+    }),
   );
 }

--- a/src/tools/entity.ts
+++ b/src/tools/entity.ts
@@ -6,7 +6,16 @@ import * as graph from "../graph/index.js";
 import * as vectorize from "../vectorize.js";
 import { assertNamespaceAccess, assertEntityAccess } from "../auth.js";
 import { parseJson, toISO } from "../utils.js";
-import { txt, ok, cap, trunc } from "../response-helpers.js";
+import {
+  txt,
+  err,
+  ok,
+  cap,
+  trunc,
+  safeMeta,
+  isMetaError,
+  toolHandler,
+} from "../response-helpers.js";
 
 export function registerEntityTools(server: McpServer, env: Env, email: string) {
   server.tool(
@@ -29,12 +38,12 @@ export function registerEntityTools(server: McpServer, env: Env, email: string) 
       idempotentHint: false,
       openWorldHint: false,
     },
-    async ({ action, id, namespace_id, name, type, summary, metadata, compact }) => {
-      const meta = metadata ? JSON.parse(metadata) : undefined;
+    toolHandler(async ({ action, id, namespace_id, name, type, summary, metadata, compact }) => {
+      const meta = safeMeta(metadata);
+      if (isMetaError(meta)) return meta;
       switch (action) {
         case "create": {
-          if (!namespace_id || !name || !type)
-            return ok("Error: namespace_id, name, type required");
+          if (!namespace_id || !name || !type) return err("namespace_id, name, type required");
           await assertNamespaceAccess(env.DB, namespace_id, email);
           const eid = await graph.createEntity(env.DB, {
             namespace_id,
@@ -53,10 +62,10 @@ export function registerEntityTools(server: McpServer, env: Env, email: string) 
           return txt({ id: eid, name, type });
         }
         case "get": {
-          if (!id) return ok("Error: id required");
+          if (!id) return err("id required");
           await assertEntityAccess(env.DB, id, email);
           const e = await graph.getEntity(env.DB, id);
-          if (!e) return ok("Not found");
+          if (!e) return err("Not found");
           const isCompact = compact ?? true;
           return txt(
             isCompact
@@ -76,9 +85,9 @@ export function registerEntityTools(server: McpServer, env: Env, email: string) 
           );
         }
         case "update": {
-          if (!id) return ok("Error: id required");
+          if (!id) return err("id required");
           if (!name && !type && !summary && !metadata)
-            return ok("Error: at least one field (name, type, summary, metadata) required");
+            return err("at least one field (name, type, summary, metadata) required");
           await assertEntityAccess(env.DB, id, email);
           await graph.updateEntity(env.DB, id, { name, type, summary, metadata: meta });
           if (name || type || summary) {
@@ -95,14 +104,14 @@ export function registerEntityTools(server: McpServer, env: Env, email: string) 
           return ok(`Updated ${id}`);
         }
         case "delete": {
-          if (!id) return ok("Error: id required");
+          if (!id) return err("id required");
           await assertEntityAccess(env.DB, id, email);
           await graph.deleteEntity(env.DB, id);
           await vectorize.deleteVector(env, "entity", id);
           return ok(`Deleted ${id}`);
         }
       }
-    },
+    }),
   );
 
   server.tool(
@@ -121,7 +130,7 @@ export function registerEntityTools(server: McpServer, env: Env, email: string) 
       readOnlyHint: true,
       openWorldHint: false,
     },
-    async ({ namespace_id, query, type, limit, compact, verbose }) => {
+    toolHandler(async ({ namespace_id, query, type, limit, compact, verbose }) => {
       await assertNamespaceAccess(env.DB, namespace_id, email);
       const results = await graph.searchEntities(env.DB, namespace_id, {
         query,
@@ -143,6 +152,6 @@ export function registerEntityTools(server: McpServer, env: Env, email: string) 
               },
         ),
       );
-    },
+    }),
   );
 }

--- a/src/tools/memory.ts
+++ b/src/tools/memory.ts
@@ -5,7 +5,16 @@ import type { Env } from "../types.js";
 import * as memories from "../memories.js";
 import * as vectorize from "../vectorize.js";
 import { assertNamespaceAccess, assertEntityAccess, assertMemoryAccess } from "../auth.js";
-import { txt, ok, cap, trunc } from "../response-helpers.js";
+import {
+  txt,
+  err,
+  ok,
+  cap,
+  trunc,
+  safeMeta,
+  isMetaError,
+  toolHandler,
+} from "../response-helpers.js";
 
 export function registerMemoryTools(server: McpServer, env: Env, email: string) {
   server.tool(
@@ -33,66 +42,69 @@ export function registerMemoryTools(server: McpServer, env: Env, email: string) 
       idempotentHint: false,
       openWorldHint: false,
     },
-    async ({
-      action,
-      id,
-      namespace_id,
-      content,
-      type,
-      importance,
-      source,
-      entity_ids,
-      metadata,
-    }) => {
-      const meta = metadata ? JSON.parse(metadata) : undefined;
-      switch (action) {
-        case "create": {
-          if (!namespace_id || !content) return ok("Error: namespace_id, content required");
-          await assertNamespaceAccess(env.DB, namespace_id, email);
-          const mid = await memories.createMemory(env.DB, {
-            namespace_id,
-            content,
-            type,
-            importance,
-            source,
-            entity_ids,
-            metadata: meta,
-          });
-          await vectorize.upsertMemoryVector(env, {
-            memory_id: mid,
-            namespace_id,
-            content,
-            type: type ?? "fact",
-          });
-          return txt({ id: mid, type: type ?? "fact" });
-        }
-        case "update": {
-          if (!id) return ok("Error: id required");
-          if (!content && !type && importance === undefined && !metadata)
-            return ok("Error: at least one field (content, type, importance, metadata) required");
-          await assertMemoryAccess(env.DB, id, email);
-          await memories.updateMemory(env.DB, id, { content, type, importance, metadata: meta });
-          if (content) {
-            const m = await memories.getMemory(env.DB, id);
-            if (m)
-              await vectorize.upsertMemoryVector(env, {
-                memory_id: id,
-                namespace_id: m.namespace_id,
-                content: m.content,
-                type: m.type,
-              });
+    toolHandler(
+      async ({
+        action,
+        id,
+        namespace_id,
+        content,
+        type,
+        importance,
+        source,
+        entity_ids,
+        metadata,
+      }) => {
+        const meta = safeMeta(metadata);
+        if (isMetaError(meta)) return meta;
+        switch (action) {
+          case "create": {
+            if (!namespace_id || !content) return err("namespace_id, content required");
+            await assertNamespaceAccess(env.DB, namespace_id, email);
+            const mid = await memories.createMemory(env.DB, {
+              namespace_id,
+              content,
+              type,
+              importance,
+              source,
+              entity_ids,
+              metadata: meta,
+            });
+            await vectorize.upsertMemoryVector(env, {
+              memory_id: mid,
+              namespace_id,
+              content,
+              type: type ?? "fact",
+            });
+            return txt({ id: mid, type: type ?? "fact" });
           }
-          return ok(`Updated ${id}`);
+          case "update": {
+            if (!id) return err("id required");
+            if (!content && !type && importance === undefined && !metadata)
+              return err("at least one field (content, type, importance, metadata) required");
+            await assertMemoryAccess(env.DB, id, email);
+            await memories.updateMemory(env.DB, id, { content, type, importance, metadata: meta });
+            if (content) {
+              const m = await memories.getMemory(env.DB, id);
+              if (m)
+                await vectorize.upsertMemoryVector(env, {
+                  memory_id: id,
+                  namespace_id: m.namespace_id,
+                  content: m.content,
+                  type: m.type,
+                });
+            }
+            return ok(`Updated ${id}`);
+          }
+          case "delete": {
+            if (!id) return err("id required");
+            await assertMemoryAccess(env.DB, id, email);
+            await memories.deleteMemory(env.DB, id);
+            await vectorize.deleteVector(env, "memory", id);
+            return ok(`Deleted ${id}`);
+          }
         }
-        case "delete": {
-          if (!id) return ok("Error: id required");
-          await assertMemoryAccess(env.DB, id, email);
-          await memories.deleteMemory(env.DB, id);
-          await vectorize.deleteVector(env, "memory", id);
-          return ok(`Deleted ${id}`);
-        }
-      }
-    },
+      },
+    ),
   );
 
   server.tool(
@@ -113,7 +125,7 @@ export function registerMemoryTools(server: McpServer, env: Env, email: string) 
       readOnlyHint: true,
       openWorldHint: false,
     },
-    async ({ mode, namespace_id, entity_id, query, type, limit, compact, verbose }) => {
+    toolHandler(async ({ mode, namespace_id, entity_id, query, type, limit, compact, verbose }) => {
       const n = cap(limit, 50, 20);
       const isCompact = compact ?? true;
       const full = verbose ?? false;
@@ -135,13 +147,13 @@ export function registerMemoryTools(server: McpServer, env: Env, email: string) 
             };
       switch (mode) {
         case "recall": {
-          if (!namespace_id) return ok("Error: namespace_id required");
+          if (!namespace_id) return err("namespace_id required");
           await assertNamespaceAccess(env.DB, namespace_id, email);
           const rows = await memories.recallMemories(env.DB, namespace_id, { type, limit: n });
           return txt(rows.map(mapMemory));
         }
         case "search": {
-          if (!namespace_id || !query) return ok("Error: namespace_id, query required");
+          if (!namespace_id || !query) return err("namespace_id, query required");
           await assertNamespaceAccess(env.DB, namespace_id, email);
           const rows = await memories.searchMemories(env.DB, namespace_id, {
             query,
@@ -151,12 +163,12 @@ export function registerMemoryTools(server: McpServer, env: Env, email: string) 
           return txt(rows.map(mapMemory));
         }
         case "entity": {
-          if (!entity_id) return ok("Error: entity_id required");
+          if (!entity_id) return err("entity_id required");
           await assertEntityAccess(env.DB, entity_id, email);
           const rows = await memories.getMemoriesForEntity(env.DB, entity_id, { limit: n });
           return txt(rows.map(mapMemory));
         }
       }
-    },
+    }),
   );
 }

--- a/src/tools/namespace.ts
+++ b/src/tools/namespace.ts
@@ -3,7 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { Env } from "../types.js";
 import * as graph from "../graph/index.js";
-import { txt, ok } from "../response-helpers.js";
+import { txt, err, toolHandler } from "../response-helpers.js";
 
 export function registerNamespaceTools(server: McpServer, env: Env, email: string) {
   server.tool(
@@ -22,9 +22,9 @@ export function registerNamespaceTools(server: McpServer, env: Env, email: strin
       idempotentHint: true,
       openWorldHint: false,
     },
-    async ({ action, name, description, compact }) => {
+    toolHandler(async ({ action, name, description, compact }) => {
       if (action === "create") {
-        if (!name) return ok("Error: name required");
+        if (!name) return err("name required");
         const id = await graph.createNamespace(env.DB, {
           name,
           description,
@@ -41,6 +41,6 @@ export function registerNamespaceTools(server: McpServer, env: Env, email: strin
             : { id: r.id, name: r.name, description: r.description },
         ),
       );
-    },
+    }),
   );
 }

--- a/src/tools/relation.ts
+++ b/src/tools/relation.ts
@@ -5,7 +5,7 @@ import type { Env } from "../types.js";
 import * as graph from "../graph/index.js";
 import { assertNamespaceAccess, assertEntityAccess, assertRelationAccess } from "../auth.js";
 import { parseJson } from "../utils.js";
-import { txt, ok, cap } from "../response-helpers.js";
+import { txt, err, ok, cap, safeMeta, isMetaError, toolHandler } from "../response-helpers.js";
 
 export function registerRelationTools(server: McpServer, env: Env, email: string) {
   server.tool(
@@ -33,31 +33,43 @@ export function registerRelationTools(server: McpServer, env: Env, email: string
       idempotentHint: false,
       openWorldHint: false,
     },
-    async ({ action, id, namespace_id, source_id, target_id, relation_type, weight, metadata }) => {
-      if (action === "create") {
-        if (!namespace_id || !source_id || !target_id || !relation_type)
-          return ok("Error: namespace_id, source_id, target_id, relation_type required");
-        await assertNamespaceAccess(env.DB, namespace_id, email);
-        // Verify both entities exist and belong to this namespace.
-        const srcNs = await assertEntityAccess(env.DB, source_id, email);
-        const tgtNs = await assertEntityAccess(env.DB, target_id, email);
-        if (srcNs !== namespace_id || tgtNs !== namespace_id)
-          return ok("Error: source and target entities must belong to the specified namespace");
-        const rid = await graph.createRelation(env.DB, {
-          namespace_id,
-          source_id,
-          target_id,
-          relation_type,
-          weight,
-          metadata: metadata ? JSON.parse(metadata) : undefined,
-        });
-        return txt({ id: rid, source_id, target_id, relation_type });
-      }
-      if (!id) return ok("Error: id required");
-      await assertRelationAccess(env.DB, id, email);
-      await graph.deleteRelation(env.DB, id);
-      return ok(`Deleted ${id}`);
-    },
+    toolHandler(
+      async ({
+        action,
+        id,
+        namespace_id,
+        source_id,
+        target_id,
+        relation_type,
+        weight,
+        metadata,
+      }) => {
+        if (action === "create") {
+          if (!namespace_id || !source_id || !target_id || !relation_type)
+            return err("namespace_id, source_id, target_id, relation_type required");
+          await assertNamespaceAccess(env.DB, namespace_id, email);
+          const srcNs = await assertEntityAccess(env.DB, source_id, email);
+          const tgtNs = await assertEntityAccess(env.DB, target_id, email);
+          if (srcNs !== namespace_id || tgtNs !== namespace_id)
+            return err("source and target entities must belong to the specified namespace");
+          const meta = safeMeta(metadata);
+          if (isMetaError(meta)) return meta;
+          const rid = await graph.createRelation(env.DB, {
+            namespace_id,
+            source_id,
+            target_id,
+            relation_type,
+            weight,
+            metadata: meta,
+          });
+          return txt({ id: rid, source_id, target_id, relation_type });
+        }
+        if (!id) return err("id required");
+        await assertRelationAccess(env.DB, id, email);
+        await graph.deleteRelation(env.DB, id);
+        return ok(`Deleted ${id}`);
+      },
+    ),
   );
 
   server.tool(
@@ -75,7 +87,7 @@ export function registerRelationTools(server: McpServer, env: Env, email: string
       readOnlyHint: true,
       openWorldHint: false,
     },
-    async ({ entity_id, direction, relation_type, limit, compact }) => {
+    toolHandler(async ({ entity_id, direction, relation_type, limit, compact }) => {
       await assertEntityAccess(env.DB, entity_id, email);
       const dir = direction ?? "both";
       const n = cap(limit, 50, 20);
@@ -120,6 +132,6 @@ export function registerRelationTools(server: McpServer, env: Env, email: string
         results.push(...rels.map(mapRel));
       }
       return txt(results);
-    },
+    }),
   );
 }

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -6,7 +6,7 @@ import * as graph from "../graph/index.js";
 import * as memories from "../memories.js";
 import * as vectorize from "../vectorize.js";
 import { assertNamespaceAccess } from "../auth.js";
-import { txt, cap, trunc } from "../response-helpers.js";
+import { txt, cap, trunc, toolHandler } from "../response-helpers.js";
 
 export function registerSearchTools(server: McpServer, env: Env, email: string) {
   server.tool(
@@ -31,7 +31,7 @@ export function registerSearchTools(server: McpServer, env: Env, email: string) 
       readOnlyHint: true,
       openWorldHint: false,
     },
-    async ({ namespace_id, query, mode, kind, type, limit, compact, verbose }) => {
+    toolHandler(async ({ namespace_id, query, mode, kind, type, limit, compact, verbose }) => {
       await assertNamespaceAccess(env.DB, namespace_id, email);
       const n = cap(limit, 20, mode === "context" ? 5 : 10);
       const isCompact = compact ?? true;
@@ -112,6 +112,6 @@ export function registerSearchTools(server: McpServer, env: Env, email: string) 
             : { content: full ? m.content : trunc(m.content), importance: m.importance }),
         })),
       });
-    },
+    }),
   );
 }

--- a/src/tools/traversal.ts
+++ b/src/tools/traversal.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import type { Env } from "../types.js";
 import * as graph from "../graph/index.js";
 import { assertEntityAccess } from "../auth.js";
-import { txt } from "../response-helpers.js";
+import { txt, toolHandler } from "../response-helpers.js";
 
 export function registerTraversalTools(server: McpServer, env: Env, email: string) {
   server.tool(
@@ -20,7 +20,7 @@ export function registerTraversalTools(server: McpServer, env: Env, email: strin
       readOnlyHint: true,
       openWorldHint: false,
     },
-    async ({ entity_id, max_depth, relation_types }) => {
+    toolHandler(async ({ entity_id, max_depth, relation_types }) => {
       await assertEntityAccess(env.DB, entity_id, email);
       return txt(
         await graph.traverse(env.DB, entity_id, {
@@ -28,6 +28,6 @@ export function registerTraversalTools(server: McpServer, env: Env, email: strin
           relationTypes: relation_types,
         }),
       );
-    },
+    }),
   );
 }


### PR DESCRIPTION
## Summary

- Add `err()` helper with `isError: true` for MCP tool error responses (LLMs can now distinguish errors from success)
- Add `safeMeta()` / `isMetaError()` to safely parse JSON metadata strings (5 unguarded `JSON.parse` calls fixed)
- Add `toolHandler()` wrapper that catches `AccessDeniedError` and unknown errors for all 14 MCP tools (22 unhandled throw sites fixed)
- Replace all 16 `ok("Error: ...")` calls with `err(...)` across 8 tool files
- Add `SyntaxError` handling to API `handleError()` (was returning 500, now 400)
- Fix admin reindex route: raw `request.json()` → `parseBody()` (only route not using the safe helper)
- Update AGENTS.md file structure description

## 11 files changed

| File | Change |
|---|---|
| `src/response-helpers.ts` | New: `err()`, `safeMeta()`, `isMetaError()`, `toolHandler()` |
| `src/tools/*.ts` (8 files) | All handlers wrapped in `toolHandler()`, `ok("Error:")` → `err()`, `JSON.parse` → `safeMeta()` |
| `src/api/middleware.ts` | `handleError()` now catches `SyntaxError` → 400 |
| `src/api/routes/admin.ts` | `request.json()` → `parseBody()` |
| `AGENTS.md` | Updated response-helpers export list |