### PR TITLE
docs: update MCP endpoint URL to public demo domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,14 @@ See [Deployment](docs/deployment.md) for full setup with Cloudflare resources.
 {
   "mcpServers": {
     "memory-graph": {
-      "url": "https://memory-graph-mcp.<your-subdomain>.workers.dev/mcp"
+      "url": "https://memory.flarelylegal.com/mcp"
     }
   }
 }
 ```
 
 Works with Claude Desktop, Cursor, OpenCode, or any MCP-compatible client.
+Access is gated by Cloudflare Access — to request a test account, open an issue or reach out.
 
 ## MCP Tools (17)
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -12,13 +12,14 @@ For Claude Desktop, Cursor, OpenCode, or any MCP-compatible client:
 {
   "mcpServers": {
     "memory-graph": {
-      "url": "https://memory-graph-mcp.<your-subdomain>.workers.dev/mcp"
+      "url": "https://memory.flarelylegal.com/mcp"
     }
   }
 }
 ```
 
 Your client opens the Cloudflare Access login page. All data is scoped to your email.
+Access is gated by Cloudflare Access — to request a test account, open an issue or reach out.
 
 ## Session state
 


### PR DESCRIPTION
## Summary
- Updates MCP client config examples in README.md and docs/mcp-tools.md to point at `memory.flarelylegal.com/mcp` instead of the placeholder `<your-subdomain>` URL
- Adds a note that access is gated by Cloudflare Access and to open an issue or reach out for a test account