### PR TITLE
docs: add FAQ, contributing, workflows README, and fix breadcrumbs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,51 @@
+# GitHub Actions Workflows
+
+[< Back to main README](../../README.md)
+
+13 workflows organized into CI, release, PR automation, and manual operations.
+
+## CI pipeline
+
+`ci.yml` orchestrates the full pipeline on push to `main` and PRs. It detects file changes with `dorny/paths-filter` and calls reusable workflows:
+
+| Workflow        | Role                                           |
+| --------------- | ---------------------------------------------- |
+| `lint.yml`      | Prettier format check + ESLint                 |
+| `typecheck.yml` | TypeScript compiler in check mode              |
+| `build.yml`     | Wrangler dry-run build, lists `dist/` output   |
+| `e2e.yml`       | Playwright E2E against site B (with preflight) |
+
+E2E tests only run when `src/`, `schemas/`, `tests/`, config files, or `playwright.config.ts` change.
+
+## Release automation
+
+`release.yml` runs on push to `main`. Uses git-cliff to calculate the next semver from conventional commits, bumps `package.json`, syncs README badges, creates a GitHub Release with changelog, and commits with `[skip ci]` to prevent loops. Uses a GitHub App token so the version bump commit can trigger downstream workflows.
+
+## PR automation
+
+| Workflow                    | Trigger                 | What it does                                                 |
+| --------------------------- | ----------------------- | ------------------------------------------------------------ |
+| `labeler.yml`               | PR open/sync            | Labels by file paths + PR size (`size/xs` through `size/xl`) |
+| `dependabot-auto-merge.yml` | PR open/sync            | Enables squash auto-merge on Dependabot PRs                  |
+| `close-stale-prs.yml`       | Daily schedule + manual | Warns after 45 days inactive, closes after 60 days           |
+
+## AI coding agent
+
+`opencode.yml` responds to `/oc` or `/opencode` commands in issue/PR comments. Runs the OpenCode agent via Cloudflare AI Gateway (Claude Sonnet 4.5).
+
+## Manual operations
+
+| Workflow            | What it does                                        |
+| ------------------- | --------------------------------------------------- |
+| `e2e-a-manual.yml`  | Playwright E2E against site A                       |
+| `seed-a-manual.yml` | Seed demo namespace on site A from a JSON seed file |
+| `seed-b-manual.yml` | Seed demo namespace on site B from a JSON seed file |
+
+## Environments
+
+Two deployed environments (A and B), each with its own Cloudflare Access service token secrets:
+
+- `CF_ACCESS_CLIENT_ID_A` / `CF_ACCESS_CLIENT_SECRET_A` / `API_BASE_URL_A`
+- `CF_ACCESS_CLIENT_ID_B` / `CF_ACCESS_CLIENT_SECRET_B` / `API_BASE_URL_B`
+
+CI runs E2E against site B automatically. Site A has manual-only workflows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,37 +8,19 @@ Memory Graph MCP — a remote MCP server on Cloudflare Workers providing LLMs wi
 
 Built on: **D1** (graph + memories + audit logs), **Vectorize** (semantic search), **Workers AI** (embeddings via `@cf/baai/bge-m3`), **KV** (caching + OAuth state), **R2** (audit log archive), **Durable Objects** (stateful MCP sessions), and **Cloudflare Access** (per-user auth via full OAuth/OIDC flow).
 
-### Key commands
+### Key commands, coding standards, and versioning
 
-See `package.json` scripts. Summary:
+See [docs/contributing.md](docs/contributing.md) for commands, checks, coding standards, branch workflow, and how to add tools/routes.
 
-| Task                   | Command                                |
-| ---------------------- | -------------------------------------- |
-| Install deps           | `npm install`                          |
-| Typecheck              | `npm run typecheck`                    |
-| Build (dry-run, A)     | `npm run build`                        |
-| Build (dry-run, B)     | `npm run build:b`                      |
-| Lint                   | `npm run lint`                         |
-| Format                 | `npm run format`                       |
-| Dev server (local, A)  | `npm run dev -- --local --port 8787`   |
-| Dev server (local, B)  | `npm run dev:b -- --local --port 8787` |
-| Init local D1 schema   | `npm run db:init:local`                |
-| Deploy (first time)    | `npm run deploy:init`                  |
-| Deploy (subsequent, A) | `npm run deploy`                       |
-| Deploy (subsequent, B) | `npm run deploy:b`                     |
+Key agent-relevant details not in contributing.md:
 
-### Versioning and releases
-
-- **Single source of truth:** version lives in `package.json` only. `src/version.ts` reads it at build time. Never hardcode version strings elsewhere.
-- **Automated releases:** pushing to `main` triggers `.github/workflows/release.yml` which uses git-cliff to calculate the next semver from conventional commits, bumps `package.json`, syncs README badges (Node, TypeScript, MCP SDK versions), creates a GitHub Release with a changelog, and commits with `[skip ci]` to prevent loops.
-- **Conventional commits required:** `feat` → minor bump, `fix` → patch bump, `feat!` / `fix!` → major bump. The changelog groups by commit type and credits PR authors.
 - **Description constants:** `src/version.ts` exports `VERSION`, `SERVER_NAME`, `SERVER_DISPLAY_NAME`, `SERVER_DESCRIPTION`, and `REPO_URL`. These are consumed by the MCP server constructor, OAuth approval page, root URL landing page, and `/health` endpoint. Update description in `version.ts` only.
+- **Deploy commands:** `npm run deploy` (site A), `npm run deploy:b` (site B), `npm run deploy:init` (first time).
 
 ### Non-obvious caveats
 
-- **Local dev requires `--local` flag:** Without a `CLOUDFLARE_API_TOKEN`, use `npx wrangler dev --local`. Without `--local`, Wrangler requires an API token for the AI and Vectorize bindings (remote services).
-- **AI and Vectorize not available locally:** When running `--local`, Workers AI and Vectorize bindings are unsupported. Tools relying on embeddings/semantic search fail gracefully. D1, KV, R2, and Durable Objects all work locally.
-- **Local D1 must be initialized:** Before first dev server run, execute `npm run db:init:local` to create SQLite tables in `.wrangler/state/`.
+Local dev setup (local flag, AI/Vectorize limitations, D1 init) is covered in [docs/contributing.md](docs/contributing.md#local-dev-caveats).
+
 - **OAuth flow requires secrets:** The full OAuth login flow needs seven secrets in `.dev.vars` (see `.dev.vars.example`): `ACCESS_CLIENT_ID`, `ACCESS_CLIENT_SECRET`, `ACCESS_TOKEN_URL`, `ACCESS_AUTHORIZATION_URL`, `ACCESS_JWKS_URL`, `ACCESS_AUD_TAG`, and `COOKIE_ENCRYPTION_KEY`. Without these, `/health` and `/register` still work, but the `/authorize` → `/callback` flow and authenticated MCP tool calls will not.
 - **JWT audience validation:** `ACCESS_AUD_TAG` is the Cloudflare Access Application Audience tag (not the OAuth client ID). It validates the `aud` claim in ID tokens to prevent cross-application token reuse.
 - **Root URL:** `GET /` returns a plain-text landing page with version, description, and repo link. All other unknown paths return 404.

--- a/README.md
+++ b/README.md
@@ -63,61 +63,20 @@ Access is gated by Cloudflare Access — to request a test account, open an issu
 
 ## MCP Tools (17)
 
-| Tool                  | Description                                               |
-| --------------------- | --------------------------------------------------------- |
-| `manage_namespace`    | Create, list, or set visibility on namespaces             |
-| `manage_entity`       | CRUD for graph entities with embedding upsert             |
-| `find_entities`       | Search entities by name/type/keyword                      |
-| `manage_relation`     | Create or delete directed relations                       |
-| `get_relations`       | Query relations from/to an entity                         |
-| `traverse_graph`      | BFS graph traversal up to max_depth hops                  |
-| `manage_memory`       | Create/update/delete memories with embedding              |
-| `query_memories`      | Recall (decay-ranked), search (keyword), or entity-linked |
-| `manage_conversation` | Create or list conversations                              |
-| `add_message`         | Add a message and embed for search                        |
-| `get_messages`        | Get or search messages                                    |
-| `search`              | Semantic vector search; context mode enriches with graph  |
-| `reindex_vectors`     | Trigger durable reindex workflow                          |
-| `consolidate_memory`  | Trigger consolidation workflow (decay, dedup, summarize)  |
-| `get_workflow_status` | Check status of a running workflow instance               |
-| `namespace_stats`     | Aggregate counts for a namespace                          |
-| `claim_namespaces`    | Claim all unowned namespaces for current user             |
-
-See [MCP Tools](docs/mcp-tools.md) for parameters and usage details.
+17 tools covering namespaces, entities, relations, traversal, memories, conversations, semantic search, and admin workflows. See [MCP Tools](docs/mcp-tools.md) for the full list with parameters and usage.
 
 ## REST API
 
 Full REST API mirrors the MCP tools with OpenAPI 3.1 spec.
 
-- **Interactive docs:** [https://memory.flarelylegal.com/api/docs](https://memory.flarelylegal.com/api/docs)
+- **Interactive docs:** [memory.flarelylegal.com/api/docs](https://memory.flarelylegal.com/api/docs)
 - **OpenAPI spec:** `GET /api/openapi.json`
 
 See [REST API](docs/rest-api.md) for authentication, endpoints, and response shaping.
 
 ## Documentation
 
-| Document                                       | Description                                  |
-| ---------------------------------------------- | -------------------------------------------- |
-| [docs/](docs/README.md)                        | Documentation index                          |
-| [docs/deployment.md](docs/deployment.md)       | Setup, resource creation, deploy, migrations |
-| [docs/configuration.md](docs/configuration.md) | Secrets, Cloudflare Access, admin role       |
-| [docs/architecture.md](docs/architecture.md)   | Components, file structure, data flow        |
-| [docs/mcp-tools.md](docs/mcp-tools.md)         | All 17 tools with parameters and usage       |
-| [docs/rest-api.md](docs/rest-api.md)           | Authentication, endpoints, service tokens    |
-| [docs/observability.md](docs/observability.md) | Audit logging, wrangler tail, monitoring     |
-| [tests/e2e/](tests/e2e/README.md)              | E2E test suite                               |
-
-## Testing
-
-```bash
-npm run typecheck
-npm run lint
-npm run build
-npm run test:e2e:a    # site A
-npm run test:e2e:b    # site B
-```
-
-See [Testing](tests/e2e/README.md) for details on targets, secrets, and running locally.
+Full docs at [docs/](docs/README.md) — deployment, configuration, architecture, MCP tools, REST API, observability, [FAQ](docs/faq.md), and [contributing](docs/contributing.md).
 
 ## Roadmap
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,15 +6,18 @@ Operational and reference documentation for Memory Graph MCP.
 
 ## Contents
 
-| Document                          | Description                                                    |
-| --------------------------------- | -------------------------------------------------------------- |
-| [Deployment](deployment.md)       | Setup, resource creation, deploy commands, database migrations |
-| [Configuration](configuration.md) | Secrets, Cloudflare Access, environment variables, admin role  |
-| [Architecture](architecture.md)   | Components, file structure, data flow, design decisions        |
-| [MCP Tools](mcp-tools.md)         | All 17 tools with parameters, actions, and usage notes         |
-| [REST API](rest-api.md)           | Authentication, endpoints, response shaping, service tokens    |
-| [Observability](observability.md) | Audit logging, `wrangler tail`, monitoring, R2 archive         |
-| [Testing](../tests/e2e/README.md) | E2E test suite, targets, secrets, running locally              |
+| Document                                | Description                                                    |
+| --------------------------------------- | -------------------------------------------------------------- |
+| [Deployment](deployment.md)             | Setup, resource creation, deploy commands, database migrations |
+| [Configuration](configuration.md)       | Secrets, Cloudflare Access, environment variables, admin role  |
+| [Architecture](architecture.md)         | Components, file structure, data flow, design decisions        |
+| [MCP Tools](mcp-tools.md)               | All 17 tools with parameters, actions, and usage notes         |
+| [REST API](rest-api.md)                 | Authentication, endpoints, response shaping, service tokens    |
+| [Observability](observability.md)       | Audit logging, `wrangler tail`, monitoring, R2 archive         |
+| [FAQ](faq.md)                           | Frequently asked questions                                     |
+| [Contributing](contributing.md)         | Setup, coding standards, branch workflow                       |
+| [CI/CD](../.github/workflows/README.md) | GitHub Actions pipeline and automation                         |
+| [Testing](../tests/e2e/README.md)       | E2E test suite, targets, secrets, running locally              |
 
 ## Quick reference
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-[< Docs](README.md) | [Configuration](configuration.md) | [MCP Tools >](mcp-tools.md)
+[< Back to docs](README.md)
 
 ## Components
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-[< Docs](README.md) | [Deployment](deployment.md) | [Architecture >](architecture.md)
+[< Back to docs](README.md)
 
 ## Secrets
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,72 @@
+# Contributing
+
+[< Back to docs](README.md) | [< Back to main README](../README.md)
+
+## Setup
+
+```bash
+npm install
+npm run db:init:local          # create local D1 tables
+npm run dev -- --local --port 8787
+```
+
+Copy `.dev.vars.example` to `.dev.vars` for the OAuth flow. Without secrets, `/health` and unauthenticated endpoints still work.
+
+## Checks
+
+All four must pass before opening a PR:
+
+```bash
+npm run typecheck
+npm run lint
+npm run format          # auto-fix; use format:check for CI
+npm run build           # wrangler dry-run
+```
+
+## Coding standards
+
+- **250-line cap** per source file. If a file grows past this, extract a focused module.
+- **One concern per file.** Don't add self-contained utilities to unrelated files. Keep helpers in the file that uses them unless they're shared.
+- **Conventional commits required.** `feat:` = minor, `fix:` = patch, `feat!:` / `fix!:` = major. Scopes encouraged (e.g. `feat(api):`, `fix(tools):`). The release workflow uses git-cliff to generate changelogs from these.
+- **Merge commits only.** Squash and rebase are disabled on the repo.
+- **MCP tools and REST API routes mirror each other.** If you add a tool, add the corresponding REST endpoint (and vice versa).
+- **Shared Zod schemas.** Field definitions live in `src/tool-schemas.ts`. MCP tools import Zod directly, REST validators compose from them, OpenAPI specs derive JSON Schema via `zodSchema()` in `api/schemas.ts`. Never duplicate field constraints.
+- **OpenAPI is auto-generated.** Each route file registers its handler and its `PathOperation`. No separate spec file.
+- **Version lives in `package.json` only.** `src/version.ts` reads it at build time. Never hardcode version strings.
+- **All write operations must be audit-logged** via `audit()` from `src/audit.ts`.
+- **All data-layer writes use `withRetry()`** from `src/db.ts` for transient D1 error resilience. Workflow steps have their own retry and don't need it.
+- **All data-layer functions accept `DbHandle`**, never raw `D1Database`.
+- **Input validation.** All tool/API inputs must have Zod `.max()` bounds on strings and arrays.
+- **Limit console.log output.** Only structural metadata — no emails, no detail, no sensitive data.
+
+## Adding an MCP tool
+
+1. Create or edit the file in `src/tools/` for the relevant domain.
+2. Import shared schemas from `src/tool-schemas.ts`.
+3. Use the `toolHandler()` wrapper from `src/response-helpers.ts` for consistent error handling.
+4. Add the corresponding REST route in `src/api/routes/`.
+5. Register the OpenAPI `PathOperation` using `zodSchema()` for request/response schemas.
+6. Audit-log write operations with `audit()`.
+7. Update the tool table in `AGENTS.md`.
+
+## Adding a REST route
+
+1. Create or edit the file in `src/api/routes/` for the relevant domain.
+2. Define the route and its `PathOperation` in the same file.
+3. Register it in `src/api/index.ts`.
+4. Use validators from `src/api/validators.ts` (composed from `src/tool-schemas.ts`).
+5. Derive OpenAPI schemas with `zodSchema()` — don't hand-write JSON Schema.
+
+## Branch workflow
+
+1. Create a branch off `main`.
+2. Make focused, conventional commits.
+3. Open a PR targeting `main`.
+4. CI runs lint, typecheck, build, and E2E (site B) automatically.
+5. Merge commit (no squash/rebase) to preserve commit granularity for release notes.
+
+## Local dev caveats
+
+- **`--local` flag required** unless you have a `CLOUDFLARE_API_TOKEN`.
+- **Workers AI and Vectorize don't work locally.** Embedding/search tools fail gracefully. D1, KV, R2, and Durable Objects work.
+- **Run `npm run db:init:local`** before first dev server run.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
 # Deployment
 
-[< Docs](README.md) | [Configuration >](configuration.md)
+[< Back to docs](README.md)
 
 ## Prerequisites
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,57 @@
+# FAQ
+
+[< Back to docs](README.md) | [< Back to main README](../README.md)
+
+Frequently asked questions about Memory Graph MCP.
+
+## General
+
+**What is this?**
+A remote MCP server on Cloudflare Workers that gives LLMs persistent structured memory — knowledge graphs, semantic search, conversation history, and temporally-decayed recall.
+
+**Can I try it?**
+The public demo runs at `memory.flarelylegal.com`. Access is gated by Cloudflare Access — open an issue or reach out to request a test account.
+
+**What MCP clients work with this?**
+Any MCP-compatible client: Claude Desktop, Cursor, OpenCode, etc. See [MCP Tools](mcp-tools.md) for connection config.
+
+## Local development
+
+**Do I need a Cloudflare account to develop locally?**
+No. Run `npm run dev -- --local --port 8787` to use local D1, KV, R2, and Durable Objects. Workers AI and Vectorize are not available locally — tools that use embeddings/search fail gracefully.
+
+**Why do I get empty tables when running locally?**
+Run `npm run db:init:local` before first use to create the D1 SQLite tables.
+
+**What secrets do I need for local dev?**
+See `.dev.vars.example`. Without secrets, `/health` and `/register` work but the OAuth login flow won't.
+
+## CI/CD
+
+**How does CI work?**
+Push to `main` or open a PR to trigger the full pipeline: lint, typecheck, build, and E2E tests (site B). See [.github/workflows/README.md](../.github/workflows/README.md) for details on all 13 workflows.
+
+**How are releases created?**
+Automated via `release.yml`. Pushing to `main` triggers git-cliff to calculate the next semver from conventional commits, bump `package.json`, generate a changelog, and create a GitHub Release. No manual version management needed.
+
+**What commit format is required?**
+[Conventional commits](https://www.conventionalcommits.org/). `feat:` = minor bump, `fix:` = patch, `feat!:` / `fix!:` = major. See [Contributing](contributing.md).
+
+## Architecture
+
+**Why Durable Objects for MCP sessions?**
+Each MCP session gets its own stateful Durable Object instance with direct access to all env bindings. Sessions auto-expire after 24 hours of inactivity.
+
+**How does auth work?**
+Cloudflare Access via a full OAuth/OIDC flow. MCP clients go through `/authorize` → `/callback`. The REST API accepts `Cf-Access-Jwt-Assertion` header or `CF_Authorization` cookie. No Bearer tokens.
+
+**Where is data stored?**
+D1 for the graph, memories, conversations, and audit logs. Vectorize for semantic search indexes. R2 for audit log archive. KV for caching and OAuth state.
+
+## Contributing
+
+**Where are the coding standards?**
+See [Contributing](contributing.md) for setup, coding standards (250-line file cap, shared Zod schemas, audit logging requirements), and the branch workflow.
+
+**How do I add a new MCP tool?**
+Add the tool in `src/tools/`, add the matching REST route in `src/api/routes/`, use shared schemas from `src/tool-schemas.ts`, and audit-log writes. Step-by-step in [Contributing](contributing.md#adding-an-mcp-tool).

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,6 +1,6 @@
 # MCP Tools
 
-[< Docs](README.md) | [Architecture](architecture.md) | [REST API >](rest-api.md)
+[< Back to docs](README.md)
 
 17 tools organized by domain. All tools require authentication via the MCP OAuth flow.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,6 +1,6 @@
 # Observability
 
-[< Docs](README.md) | [REST API](rest-api.md) | [Testing](../tests/e2e/README.md)
+[< Back to docs](README.md)
 
 ## Audit logging
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -1,6 +1,6 @@
 # REST API
 
-[< Docs](README.md) | [MCP Tools](mcp-tools.md) | [Observability >](observability.md)
+[< Back to docs](README.md)
 
 ## Live docs
 


### PR DESCRIPTION
## Summary
- Adds `docs/faq.md` (General, Local dev, CI/CD, Architecture, Contributing sections)
- Adds `docs/contributing.md` (setup, checks, coding standards, adding tools/routes, branch workflow)
- Adds `.github/workflows/README.md` (documents all 13 workflows)
- Standardizes breadcrumbs: `docs/*.md` → `docs/README.md`, FAQ + contributing also link back to main README
- Adds workflows README and contributing to doc index tables
- Trims root README: replaces 17-row tools table and 11-row docs table with concise links, removes testing section (now in contributing)
- Moves key commands, versioning, and local dev caveats from AGENTS.md to contributing.md (AGENTS.md now points there)