### PR TITLE
feat(namespace): add namespace delete with cascade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Code is organized into focused modules with a 250-line cap per file:
 
 | Tool                  | Domain       | Description                                                     |
 | --------------------- | ------------ | --------------------------------------------------------------- |
-| `manage_namespace`    | namespace    | Create, list, or set visibility on namespaces                   |
+| `manage_namespace`    | namespace    | Create, list, delete, or set visibility on namespaces           |
 | `manage_entity`       | entity       | CRUD for graph entities with embedding upsert                   |
 | `find_entities`       | entity       | Search entities by name/type/keyword                            |
 | `manage_relation`     | relation     | Create or delete directed relations (with ownership check)      |

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -33,11 +33,11 @@ The server tracks active context across tool calls:
 
 ### Namespace
 
-| Tool               | Description                                   |
-| ------------------ | --------------------------------------------- |
-| `manage_namespace` | Create, list, or set visibility on namespaces |
+| Tool               | Description                                           |
+| ------------------ | ----------------------------------------------------- |
+| `manage_namespace` | Create, list, delete, or set visibility on namespaces |
 
-Actions: `create` (requires `name`), `list`, `set_visibility` (admin only, requires `id` + `visibility`).
+Actions: `create` (requires `name`), `list`, `delete` (requires `id`, prompts for confirmation), `set_visibility` (admin only, requires `id` + `visibility`). Delete cascades all entities, relations, memories, conversations, messages, and Vectorize vectors.
 
 ### Entity
 

--- a/src/api/routes/namespaces.ts
+++ b/src/api/routes/namespaces.ts
@@ -2,7 +2,14 @@
 import { z } from "zod";
 import { defineRoute } from "../registry.js";
 import { json, jsonError, parseBody, handleError } from "../middleware.js";
-import { createNamespace, listNamespaces, updateNamespaceVisibility } from "../../graph/index.js";
+import {
+  createNamespace,
+  listNamespaces,
+  updateNamespaceVisibility,
+  collectNamespaceVectorIds,
+  deleteNamespace,
+} from "../../graph/index.js";
+import { deleteVectorBatch } from "../../vectorize.js";
 import { assertNamespaceWriteAccess, isAdmin } from "../../auth.js";
 import { nameField, descriptionField, visibility } from "../../tool-schemas.js";
 import { namespaceSchema, okSchema, zodSchema } from "../schemas.js";
@@ -182,6 +189,53 @@ export function registerNamespaceRoutes(): void {
       responses: {
         "200": {
           description: "Updated",
+          content: { "application/json": { schema: okSchema() } },
+        },
+      },
+    },
+  );
+
+  defineRoute(
+    "DELETE",
+    "/api/v1/namespaces/:id",
+    async (ctx) => {
+      try {
+        const admin = await isAdmin(ctx.env.CACHE, ctx.email);
+        const ns = await assertNamespaceWriteAccess(ctx.db, ctx.params.id, ctx.email, admin);
+        const vectorIds = await collectNamespaceVectorIds(ctx.db, ctx.params.id);
+        await deleteNamespace(ctx.db, ctx.params.id);
+        await deleteVectorBatch(ctx.env, vectorIds);
+        await audit(ctx.db, ctx.env.STORAGE, {
+          action: "namespace.delete",
+          email: ctx.email,
+          namespace_id: ctx.params.id,
+          resource_type: "namespace",
+          resource_id: ctx.params.id,
+          detail: { name: ns.name, vectors_deleted: vectorIds.length },
+        });
+        return json({ ok: true });
+      } catch (e) {
+        return handleError(e);
+      }
+    },
+    {
+      summary: "Delete namespace",
+      description:
+        "Delete a namespace and all its contents (entities, relations, memories, conversations, messages). Vectors are removed from Vectorize. Owner or admin required.",
+      tags: ["Namespaces"],
+      operationId: "deleteNamespace",
+      parameters: [
+        {
+          name: "id",
+          in: "path",
+          required: true,
+          description: "Namespace ID",
+          schema: { type: "string", format: "uuid" },
+        },
+      ],
+      responses: {
+        "200": {
+          description: "Deleted",
           content: { "application/json": { schema: okSchema() } },
         },
       },

--- a/src/audit.ts
+++ b/src/audit.ts
@@ -20,7 +20,7 @@ import { generateId, now } from "./utils.js";
 // ---------------------------------------------------------------------------
 
 export type AuditAction =
-  | "namespace.create" | "namespace.claim" | "namespace.set_visibility"
+  | "namespace.create" | "namespace.delete" | "namespace.claim" | "namespace.set_visibility"
   | "entity.create" | "entity.update" | "entity.delete"
   | "relation.create" | "relation.delete"
   | "memory.create" | "memory.update" | "memory.delete"

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -4,6 +4,8 @@ export {
   getNamespace,
   listNamespaces,
   updateNamespaceVisibility,
+  collectNamespaceVectorIds,
+  deleteNamespace,
   claimUnownedNamespaces,
 } from "./namespaces.js";
 export { createEntity, getEntity, searchEntities, updateEntity, deleteEntity } from "./entities.js";

--- a/src/graph/namespaces.ts
+++ b/src/graph/namespaces.ts
@@ -76,6 +76,42 @@ export async function updateNamespaceVisibility(
   );
 }
 
+/**
+ * Collect all vector IDs for a namespace (entities, memories, messages).
+ * Must be called BEFORE deleting the namespace since cascade removes the rows.
+ */
+export async function collectNamespaceVectorIds(
+  db: DbHandle,
+  namespaceId: string,
+): Promise<string[]> {
+  const [entities, memories, messages] = await Promise.all([
+    db
+      .prepare(`SELECT id FROM entities WHERE namespace_id = ?`)
+      .bind(namespaceId)
+      .all<{ id: string }>(),
+    db
+      .prepare(`SELECT id FROM memories WHERE namespace_id = ?`)
+      .bind(namespaceId)
+      .all<{ id: string }>(),
+    db
+      .prepare(
+        `SELECT m.id FROM messages m JOIN conversations c ON c.id = m.conversation_id WHERE c.namespace_id = ?`,
+      )
+      .bind(namespaceId)
+      .all<{ id: string }>(),
+  ]);
+  return [
+    ...entities.results.map((r) => `entity:${r.id}`),
+    ...memories.results.map((r) => `memory:${r.id}`),
+    ...messages.results.map((r) => `message:${r.id}`),
+  ];
+}
+
+/** Delete a namespace and all its contents. D1 ON DELETE CASCADE handles child rows. */
+export async function deleteNamespace(db: DbHandle, id: string): Promise<void> {
+  await withRetry(() => db.prepare(`DELETE FROM namespaces WHERE id = ?`).bind(id).run());
+}
+
 export async function claimUnownedNamespaces(db: DbHandle, owner: string): Promise<number> {
   const result = await withRetry(() =>
     db.prepare(`UPDATE namespaces SET owner = ? WHERE owner IS NULL`).bind(owner).run(),

--- a/src/tools/namespace.ts
+++ b/src/tools/namespace.ts
@@ -5,10 +5,11 @@ import { nameField, descriptionField, visibility } from "../tool-schemas.js";
 import type { Env, StateHandle } from "../types.js";
 import { session } from "../db.js";
 import * as graph from "../graph/index.js";
+import { deleteVectorBatch } from "../vectorize.js";
 import { assertNamespaceWriteAccess, isAdmin } from "../auth.js";
 import { track } from "../state.js";
 import { audit } from "../audit.js";
-import { txt, err, ok, toolHandler } from "../response-helpers.js";
+import { txt, err, ok, confirm, toolHandler } from "../response-helpers.js";
 
 export function registerNamespaceTools(
   server: McpServer,
@@ -18,10 +19,10 @@ export function registerNamespaceTools(
 ) {
   server.tool(
     "manage_namespace",
-    "Create, list, or set visibility on memory namespaces.",
+    "Create, list, delete, or set visibility on memory namespaces.",
     {
-      action: z.enum(["create", "list", "set_visibility"]),
-      id: z.string().uuid().optional().describe("Required for set_visibility"),
+      action: z.enum(["create", "list", "delete", "set_visibility"]),
+      id: z.string().uuid().optional().describe("Required for delete and set_visibility"),
       name: nameField.optional().describe("Required for create"),
       description: descriptionField.optional(),
       visibility: visibility.optional().describe("Required for set_visibility (admin only)"),
@@ -30,8 +31,8 @@ export function registerNamespaceTools(
     {
       title: "Manage Namespace",
       readOnlyHint: false,
-      destructiveHint: false,
-      idempotentHint: true,
+      destructiveHint: true,
+      idempotentHint: false,
       openWorldHint: false,
     },
     toolHandler(async ({ action, id, name, description, visibility, compact }) => {
@@ -53,6 +54,26 @@ export function registerNamespaceTools(
           detail: { name },
         });
         return txt({ id: nsId, name });
+      }
+      if (action === "delete") {
+        if (!id) return err("id required");
+        const db = session(env.DB, "first-primary");
+        const admin = await isAdmin(env.CACHE, email);
+        const ns = await assertNamespaceWriteAccess(db, id, email, admin);
+        if (!(await confirm(server, `Delete namespace "${ns.name}" and ALL its contents?`)))
+          return ok("Cancelled");
+        const vectorIds = await graph.collectNamespaceVectorIds(db, id);
+        await graph.deleteNamespace(db, id);
+        await deleteVectorBatch(env, vectorIds);
+        await audit(db, env.STORAGE, {
+          action: "namespace.delete",
+          email,
+          namespace_id: id,
+          resource_type: "namespace",
+          resource_id: id,
+          detail: { name: ns.name, vectors_deleted: vectorIds.length },
+        });
+        return ok(`Deleted namespace "${ns.name}" (${vectorIds.length} vectors removed)`);
       }
       if (action === "set_visibility") {
         if (!id || !visibility) return err("id and visibility required");

--- a/src/vectorize.ts
+++ b/src/vectorize.ts
@@ -112,6 +112,16 @@ export async function deleteVector(env: Env, kind: string, id: string): Promise<
   await env.VECTORIZE.deleteByIds([`${kind}:${id}`]);
 }
 
+/** Batch-delete vectors by their full prefixed IDs. Chunks to stay within limits. */
+export async function deleteVectorBatch(env: Env, ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  // Vectorize deleteByIds supports up to 1000 IDs per call
+  const CHUNK = 1000;
+  for (let i = 0; i < ids.length; i += CHUNK) {
+    await env.VECTORIZE.deleteByIds(ids.slice(i, i + CHUNK));
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Semantic search
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `manage_namespace` `delete` action (MCP tool) with elicitation confirmation
- Adds `DELETE /api/v1/namespaces/:id` (REST API)
- Cascade: D1 `ON DELETE CASCADE` handles entities, relations, memories, conversations, messages, memory_entity_links; Vectorize vectors batch-deleted separately
- Ownership check: only namespace owner or admin (for public namespaces) can delete
- Audit-logged as `namespace.delete` with vector count in detail

Closes #43